### PR TITLE
[codex] Render static primitive nodes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -14,16 +14,29 @@ describe("App shell", () => {
     expect(screen.getAllByText(/local workspace/i).length).toBeGreaterThan(0);
   });
 
-  it("renders an empty graph canvas without architecture nodes", () => {
+  it("renders deterministic primitive architecture nodes on the canvas", () => {
     render(<App />);
 
     expect(
       screen.getByRole("region", { name: /graph canvas/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/canvas is empty/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/ready for architecture layout/i),
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("architecture-node")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("architecture-node")).toHaveLength(4);
+    expect(screen.getByText("Tensor")).toBeInTheDocument();
+    expect(screen.getByText("Neuron")).toBeInTheDocument();
+    expect(screen.getByText("Activation")).toBeInTheDocument();
+    expect(screen.getByText("Dense / Linear")).toBeInTheDocument();
+    expect(screen.queryByText("Convolution")).not.toBeInTheDocument();
+  });
+
+  it("shows readable metadata for each primitive node without editing controls", () => {
+    render(<App />);
+
+    expect(screen.queryByText(/canvas is empty/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Role: data carrier")).toBeInTheDocument();
+    expect(screen.getByText("Lowest exposed primitive")).toBeInTheDocument();
+    expect(screen.getByText("Function: GELU")).toBeInTheDocument();
+    expect(screen.getByText("Derived from neuron primitives")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,17 @@ import {
   PanelLeft,
 } from "lucide-react";
 import { Background, ReactFlow } from "@xyflow/react";
-import type { Edge, Node } from "@xyflow/react";
+import type { Edge, Node, NodeProps, NodeTypes } from "@xyflow/react";
 
 import "@xyflow/react/dist/style.css";
+
+type PrimitiveNode = {
+  id: string;
+  label: string;
+  kind: string;
+  metadata: string[];
+  position: { x: number; y: number };
+};
 
 const workspaceItems = [
   { label: "Project", value: "Untitled graph" },
@@ -17,7 +25,75 @@ const workspaceItems = [
   { label: "Runtime", value: "Not configured" },
 ];
 
-const canvasNodes: Node[] = [];
+const primitiveNodes: PrimitiveNode[] = [
+  {
+    id: "tensor",
+    label: "Tensor",
+    kind: "Data",
+    metadata: ["Role: data carrier", "Shape: dynamic"],
+    position: { x: 96, y: 64 },
+  },
+  {
+    id: "neuron",
+    label: "Neuron",
+    kind: "Foundation",
+    metadata: ["Lowest exposed primitive", "Parameters: weights + bias"],
+    position: { x: 96, y: 216 },
+  },
+  {
+    id: "activation",
+    label: "Activation",
+    kind: "Primitive",
+    metadata: ["Function: GELU", "Role: nonlinear transform"],
+    position: { x: 96, y: 368 },
+  },
+  {
+    id: "dense-linear",
+    label: "Dense / Linear",
+    kind: "Built-in",
+    metadata: ["Units: 128", "Derived from neuron primitives"],
+    position: { x: 96, y: 520 },
+  },
+];
+
+type PrimitiveNodeData = Omit<PrimitiveNode, "id" | "position">;
+type PrimitiveFlowNode = Node<PrimitiveNodeData, "primitive">;
+
+function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
+  return (
+    <article
+      className="architecture-node"
+      data-testid="architecture-node"
+      aria-label={`${data.label} primitive node`}
+    >
+      <span className="architecture-node-kind">{data.kind}</span>
+      <h4>{data.label}</h4>
+      <ul>
+        {data.metadata.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+const nodeTypes: NodeTypes = {
+  primitive: PrimitiveNodeCard,
+};
+
+const canvasNodes: PrimitiveFlowNode[] = primitiveNodes.map((node) => ({
+  id: node.id,
+  type: "primitive",
+  position: node.position,
+  data: {
+    label: node.label,
+    kind: node.kind,
+    metadata: node.metadata,
+  },
+  className: "architecture-flow-node",
+  selectable: false,
+  draggable: false,
+}));
 const canvasEdges: Edge[] = [];
 
 export function App() {
@@ -82,6 +158,7 @@ export function App() {
             <ReactFlow
               nodes={canvasNodes}
               edges={canvasEdges}
+              nodeTypes={nodeTypes}
               nodesDraggable={false}
               nodesConnectable={false}
               elementsSelectable={false}
@@ -90,17 +167,20 @@ export function App() {
               zoomOnPinch={false}
               zoomOnDoubleClick={false}
               preventScrolling={false}
+              defaultViewport={{ x: 0, y: 0, zoom: 1 }}
             >
               <Background color="#c2d0ca" gap={28} size={1.25} />
             </ReactFlow>
 
-            <div className="canvas-empty-state">
-              <CircuitBoard size={38} strokeWidth={1.6} aria-hidden="true" />
-              <div>
-                <p>Canvas is empty</p>
-                <span>Ready for architecture layout</span>
+            {canvasNodes.length === 0 ? (
+              <div className="canvas-empty-state">
+                <CircuitBoard size={38} strokeWidth={1.6} aria-hidden="true" />
+                <div>
+                  <p>Canvas is empty</p>
+                  <span>Ready for architecture layout</span>
+                </div>
               </div>
-            </div>
+            ) : null}
           </section>
         </section>
       </main>

--- a/src/styles.css
+++ b/src/styles.css
@@ -127,6 +127,10 @@ h3 {
   font-weight: 740;
 }
 
+h4 {
+  margin: 0;
+}
+
 .nav-list {
   display: grid;
   gap: 6px;
@@ -248,7 +252,7 @@ h3 {
 
 .graph-canvas {
   position: relative;
-  min-height: min(58vh, 620px);
+  min-height: 660px;
   overflow: hidden;
   background:
     linear-gradient(90deg, rgb(15 143 125 / 5%) 1px, transparent 1px),
@@ -265,6 +269,60 @@ h3 {
 .graph-canvas .react-flow__attribution {
   background: rgb(248 250 248 / 82%);
   color: var(--ink-muted);
+}
+
+.graph-canvas .react-flow__node.architecture-flow-node {
+  width: 214px;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  cursor: default;
+}
+
+.architecture-node {
+  display: grid;
+  gap: 10px;
+  height: 132px;
+  align-content: start;
+  padding: 14px;
+  color: var(--ink);
+  background: #ffffff;
+  border: 1px solid rgb(15 143 125 / 32%);
+  border-left: 4px solid var(--accent);
+  border-radius: 8px;
+  box-shadow: 0 14px 30px rgb(23 33 31 / 14%);
+}
+
+.architecture-node-kind {
+  width: fit-content;
+  padding: 3px 8px;
+  color: var(--accent-strong);
+  background: rgb(15 143 125 / 10%);
+  border: 1px solid rgb(15 143 125 / 18%);
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 780;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.architecture-node h4 {
+  color: var(--ink);
+  font-size: 0.98rem;
+  font-weight: 780;
+  line-height: 1.15;
+}
+
+.architecture-node ul {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  color: var(--ink-muted);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.25;
+  list-style: none;
 }
 
 .canvas-empty-state {
@@ -347,7 +405,7 @@ h3 {
   }
 
   .graph-canvas {
-    min-height: 360px;
+    min-height: 660px;
   }
 
   .canvas-empty-state {


### PR DESCRIPTION
## Summary
- Render deterministic static primitive nodes on the graph canvas: Tensor, Neuron, Activation, and Dense / Linear.
- Add readable kind and metadata cards aligned with the PRD primitive strategy.
- Keep the canvas static and non-interactive: no creation, drag, selection, connections, inspector, editing, validation, persistence, or runtime.

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- Manual browser check at `http://localhost:1420/`: four nodes visible with even spacing, no empty state, and no interactive controls.

Closes #6
