### PR TITLE
[codex] Select node and open inspector

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { App } from "./App";
@@ -35,8 +35,50 @@ describe("App shell", () => {
     expect(screen.getByText("Role: data carrier")).toBeInTheDocument();
     expect(screen.getByText("Lowest exposed primitive")).toBeInTheDocument();
     expect(screen.getByText("Function: GELU")).toBeInTheDocument();
-    expect(screen.getByText("Derived from neuron primitives")).toBeInTheDocument();
+    expect(
+      screen.getByText("Derived from neuron primitives"),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("shows a clear inspector state when no node is selected", () => {
+    render(<App />);
+
+    expect(
+      screen.getByRole("complementary", { name: /node inspector/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /inspector/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no node selected/i)).toBeInTheDocument();
+    expect(screen.getByText(/select a primitive node/i)).toBeInTheDocument();
+  });
+
+  it("selects a primitive node and shows its read-only inspector details", () => {
+    render(<App />);
+
+    const neuronNode = screen.getByLabelText(/neuron primitive node/i);
+    const tensorNode = screen.getByLabelText(/tensor primitive node/i);
+
+    fireEvent.click(neuronNode);
+
+    expect(neuronNode).toHaveAttribute("aria-pressed", "true");
+    expect(tensorNode).toHaveAttribute("aria-pressed", "false");
+    const inspector = screen.getByRole("complementary", {
+      name: /node inspector/i,
+    });
+    expect(
+      within(inspector).getByRole("heading", { name: /neuron/i }),
+    ).toBeInTheDocument();
+    expect(within(inspector).getByText("Foundation")).toBeInTheDocument();
+    expect(
+      within(inspector).getByText("Lowest exposed primitive"),
+    ).toBeInTheDocument();
+    expect(
+      within(inspector).getByText("Parameters: weights + bias"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,11 @@ import {
   CircuitBoard,
   FlaskConical,
   Folder,
+  Info,
   PanelLeft,
 } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { KeyboardEvent } from "react";
 import { Background, ReactFlow } from "@xyflow/react";
 import type { Edge, Node, NodeProps, NodeTypes } from "@xyflow/react";
 
@@ -56,15 +59,34 @@ const primitiveNodes: PrimitiveNode[] = [
   },
 ];
 
-type PrimitiveNodeData = Omit<PrimitiveNode, "id" | "position">;
+type PrimitiveNodeData = Omit<PrimitiveNode, "position"> & {
+  isSelected: boolean;
+  onSelect: (nodeId: string) => void;
+};
 type PrimitiveFlowNode = Node<PrimitiveNodeData, "primitive">;
 
 function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
+  const selectNode = () => {
+    data.onSelect(data.id);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      selectNode();
+    }
+  };
+
   return (
     <article
-      className="architecture-node"
+      className={`architecture-node${data.isSelected ? " selected" : ""}`}
       data-testid="architecture-node"
+      role="button"
+      tabIndex={0}
+      aria-pressed={data.isSelected}
       aria-label={`${data.label} primitive node`}
+      onClick={selectNode}
+      onKeyDown={handleKeyDown}
     >
       <span className="architecture-node-kind">{data.kind}</span>
       <h4>{data.label}</h4>
@@ -81,22 +103,35 @@ const nodeTypes: NodeTypes = {
   primitive: PrimitiveNodeCard,
 };
 
-const canvasNodes: PrimitiveFlowNode[] = primitiveNodes.map((node) => ({
-  id: node.id,
-  type: "primitive",
-  position: node.position,
-  data: {
-    label: node.label,
-    kind: node.kind,
-    metadata: node.metadata,
-  },
-  className: "architecture-flow-node",
-  selectable: false,
-  draggable: false,
-}));
 const canvasEdges: Edge[] = [];
 
 export function App() {
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const selectedNode =
+    primitiveNodes.find((node) => node.id === selectedNodeId) ?? null;
+
+  const canvasNodes: PrimitiveFlowNode[] = useMemo(
+    () =>
+      primitiveNodes.map((node) => ({
+        id: node.id,
+        type: "primitive",
+        position: node.position,
+        data: {
+          id: node.id,
+          label: node.label,
+          kind: node.kind,
+          metadata: node.metadata,
+          isSelected: selectedNodeId === node.id,
+          onSelect: setSelectedNodeId,
+        },
+        className: "architecture-flow-node",
+        selected: selectedNodeId === node.id,
+        selectable: true,
+        draggable: false,
+      })),
+    [selectedNodeId],
+  );
+
   return (
     <div className="app-shell">
       <aside className="sidebar" aria-label="Primary">
@@ -139,19 +174,47 @@ export function App() {
         </header>
 
         <section className="workbench" aria-label="Project overview">
-          <div className="workspace-panel">
-            <div className="panel-heading">
-              <Folder size={18} aria-hidden="true" />
-              <h3>Session</h3>
+          <div className="workspace-panel-stack">
+            <div className="workspace-panel">
+              <div className="panel-heading">
+                <Folder size={18} aria-hidden="true" />
+                <h3>Session</h3>
+              </div>
+              <dl className="meta-list">
+                {workspaceItems.map((item) => (
+                  <div className="meta-row" key={item.label}>
+                    <dt>{item.label}</dt>
+                    <dd>{item.value}</dd>
+                  </div>
+                ))}
+              </dl>
             </div>
-            <dl className="meta-list">
-              {workspaceItems.map((item) => (
-                <div className="meta-row" key={item.label}>
-                  <dt>{item.label}</dt>
-                  <dd>{item.value}</dd>
+
+            <aside className="workspace-panel" aria-label="Node inspector">
+              <div className="panel-heading">
+                <Info size={18} aria-hidden="true" />
+                <h3>Inspector</h3>
+              </div>
+
+              {selectedNode ? (
+                <div className="inspector-details">
+                  <span className="architecture-node-kind">
+                    {selectedNode.kind}
+                  </span>
+                  <h4>{selectedNode.label}</h4>
+                  <ul>
+                    {selectedNode.metadata.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
                 </div>
-              ))}
-            </dl>
+              ) : (
+                <div className="inspector-empty">
+                  <p>No node selected</p>
+                  <span>Select a primitive node on the canvas.</span>
+                </div>
+              )}
+            </aside>
           </div>
 
           <section className="graph-canvas" aria-label="Graph canvas">

--- a/src/styles.css
+++ b/src/styles.css
@@ -210,6 +210,12 @@ h4 {
   padding: 18px;
 }
 
+.workspace-panel-stack {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
 .panel-heading {
   display: flex;
   align-items: center;
@@ -276,14 +282,16 @@ h4 {
   background: transparent;
   border: 0;
   box-shadow: none;
-  cursor: default;
+  cursor: pointer;
 }
 
 .architecture-node {
   display: grid;
   gap: 10px;
   height: 132px;
+  width: 100%;
   align-content: start;
+  text-align: left;
   padding: 14px;
   color: var(--ink);
   background: #ffffff;
@@ -291,6 +299,18 @@ h4 {
   border-left: 4px solid var(--accent);
   border-radius: 8px;
   box-shadow: 0 14px 30px rgb(23 33 31 / 14%);
+  outline: none;
+  cursor: pointer;
+}
+
+.architecture-node:hover,
+.architecture-node:focus-visible,
+.architecture-node.selected {
+  border-color: rgb(199 123 23 / 62%);
+  border-left-color: var(--signal);
+  box-shadow:
+    0 0 0 3px rgb(199 123 23 / 18%),
+    0 16px 34px rgb(23 33 31 / 18%);
 }
 
 .architecture-node-kind {
@@ -323,6 +343,49 @@ h4 {
   font-weight: 650;
   line-height: 1.25;
   list-style: none;
+}
+
+.inspector-details {
+  display: grid;
+  gap: 12px;
+}
+
+.inspector-details h4 {
+  color: var(--ink);
+  font-size: 1.05rem;
+  font-weight: 780;
+  line-height: 1.15;
+}
+
+.inspector-details ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  color: var(--ink-muted);
+  font-size: 0.86rem;
+  font-weight: 650;
+  line-height: 1.3;
+  list-style: none;
+}
+
+.inspector-empty {
+  display: grid;
+  gap: 6px;
+  color: var(--ink-muted);
+}
+
+.inspector-empty p {
+  margin-bottom: 0;
+  color: var(--ink);
+  font-size: 0.96rem;
+  font-weight: 730;
+}
+
+.inspector-empty span {
+  font-size: 0.86rem;
+  font-weight: 650;
+  line-height: 1.35;
 }
 
 .canvas-empty-state {


### PR DESCRIPTION
## Summary

- Adds primitive node selection state to the static graph canvas.
- Adds a read-only Node inspector with a clear empty state and selected node details.
- Adds focused tests for empty inspector state and selecting a primitive node.

Closes #7

## Verification

Automated:

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm format:check`
- `git diff --check`

Manual:

- Started the app locally with Vite.
- Confirmed the initial Inspector state shows `No node selected`.
- Selected the `Neuron` node and confirmed it is visually selected and marked pressed.
- Confirmed the Inspector shows `Foundation`, `Lowest exposed primitive`, and `Parameters: weights + bias`.
- Confirmed primitive nodes remain visible and no editing controls were introduced.

Screenshot captured locally at `output/playwright/issue-7-node-inspector.png`.