### PR TITLE
[codex] Implement editable node parameters

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -28,7 +28,7 @@ describe("App shell", () => {
     expect(screen.queryByText("Convolution")).not.toBeInTheDocument();
   });
 
-  it("shows readable metadata for each primitive node without editing controls", () => {
+  it("shows readable metadata for each primitive node before selection", () => {
     render(<App />);
 
     expect(screen.queryByText(/canvas is empty/i)).not.toBeInTheDocument();
@@ -38,9 +38,6 @@ describe("App shell", () => {
     expect(
       screen.getByText("Derived from neuron primitives"),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
-    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
 
   it("shows a clear inspector state when no node is selected", () => {
@@ -56,7 +53,7 @@ describe("App shell", () => {
     expect(screen.getByText(/select a primitive node/i)).toBeInTheDocument();
   });
 
-  it("selects a primitive node and shows its read-only inspector details", () => {
+  it("selects a primitive node and shows editable inspector details", () => {
     render(<App />);
 
     const neuronNode = screen.getByLabelText(/neuron primitive node/i);
@@ -79,6 +76,54 @@ describe("App shell", () => {
     expect(
       within(inspector).getByText("Parameters: weights + bias"),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(
+      within(inspector).getByRole("spinbutton", { name: /units/i }),
+    ).toHaveValue(1);
+    expect(
+      within(inspector).getByRole("checkbox", { name: /bias/i }),
+    ).toBeChecked();
+  });
+
+  it("updates selected node parameters and keeps values associated with each node", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/dense \/ linear primitive node/i));
+    const inspector = screen.getByRole("complementary", {
+      name: /node inspector/i,
+    });
+    const unitsInput = within(inspector).getByRole("spinbutton", {
+      name: /units/i,
+    });
+
+    fireEvent.change(unitsInput, { target: { value: "256" } });
+
+    expect(unitsInput).toHaveValue(256);
+    expect(within(inspector).getByText("Units: 256")).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByLabelText(/dense \/ linear primitive node/i),
+      ).getByText("Units: 256"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/activation primitive node/i));
+    const activationSelect = within(inspector).getByRole("combobox", {
+      name: /function/i,
+    });
+
+    fireEvent.change(activationSelect, { target: { value: "ReLU" } });
+
+    expect(activationSelect).toHaveValue("ReLU");
+    expect(within(inspector).getByText("Function: ReLU")).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText(/activation primitive node/i)).getByText(
+        "Function: ReLU",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/dense \/ linear primitive node/i));
+
+    expect(
+      within(inspector).getByRole("spinbutton", { name: /units/i }),
+    ).toHaveValue(256);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,17 +8,47 @@ import {
   PanelLeft,
 } from "lucide-react";
 import { useMemo, useState } from "react";
-import type { KeyboardEvent } from "react";
+import type { ChangeEvent, KeyboardEvent } from "react";
 import { Background, ReactFlow } from "@xyflow/react";
 import type { Edge, Node, NodeProps, NodeTypes } from "@xyflow/react";
 
 import "@xyflow/react/dist/style.css";
+
+type PrimitiveNodeParameter =
+  | {
+      id: string;
+      label: string;
+      type: "number";
+      value: number;
+      min?: number;
+      step?: number;
+    }
+  | {
+      id: string;
+      label: string;
+      type: "select";
+      value: string;
+      options: string[];
+    }
+  | {
+      id: string;
+      label: string;
+      type: "text";
+      value: string;
+    }
+  | {
+      id: string;
+      label: string;
+      type: "boolean";
+      value: boolean;
+    };
 
 type PrimitiveNode = {
   id: string;
   label: string;
   kind: string;
   metadata: string[];
+  parameters: PrimitiveNodeParameter[];
   position: { x: number; y: number };
 };
 
@@ -33,7 +63,10 @@ const primitiveNodes: PrimitiveNode[] = [
     id: "tensor",
     label: "Tensor",
     kind: "Data",
-    metadata: ["Role: data carrier", "Shape: dynamic"],
+    metadata: ["Role: data carrier"],
+    parameters: [
+      { id: "shape", label: "Shape", type: "text", value: "dynamic" },
+    ],
     position: { x: 96, y: 64 },
   },
   {
@@ -41,29 +74,75 @@ const primitiveNodes: PrimitiveNode[] = [
     label: "Neuron",
     kind: "Foundation",
     metadata: ["Lowest exposed primitive", "Parameters: weights + bias"],
-    position: { x: 96, y: 216 },
+    parameters: [
+      {
+        id: "units",
+        label: "Units",
+        type: "number",
+        value: 1,
+        min: 1,
+        step: 1,
+      },
+      { id: "bias", label: "Bias", type: "boolean", value: true },
+    ],
+    position: { x: 96, y: 244 },
   },
   {
     id: "activation",
     label: "Activation",
     kind: "Primitive",
-    metadata: ["Function: GELU", "Role: nonlinear transform"],
-    position: { x: 96, y: 368 },
+    metadata: ["Role: nonlinear transform"],
+    parameters: [
+      {
+        id: "function",
+        label: "Function",
+        type: "select",
+        value: "GELU",
+        options: ["GELU", "ReLU", "SiLU", "Tanh"],
+      },
+    ],
+    position: { x: 96, y: 424 },
   },
   {
     id: "dense-linear",
     label: "Dense / Linear",
     kind: "Built-in",
-    metadata: ["Units: 128", "Derived from neuron primitives"],
-    position: { x: 96, y: 520 },
+    metadata: ["Derived from neuron primitives"],
+    parameters: [
+      {
+        id: "units",
+        label: "Units",
+        type: "number",
+        value: 128,
+        min: 1,
+        step: 1,
+      },
+    ],
+    position: { x: 96, y: 604 },
   },
 ];
 
 type PrimitiveNodeData = Omit<PrimitiveNode, "position"> & {
   isSelected: boolean;
   onSelect: (nodeId: string) => void;
+  displayMetadata: string[];
 };
 type PrimitiveFlowNode = Node<PrimitiveNodeData, "primitive">;
+
+function formatParameterSummary(parameter: PrimitiveNodeParameter) {
+  if (parameter.type === "boolean") {
+    return `${parameter.label}: ${parameter.value ? "enabled" : "disabled"}`;
+  }
+
+  return `${parameter.label}: ${parameter.value}`;
+}
+
+function getDisplayMetadata(node: PrimitiveNode) {
+  return [
+    ...node.parameters.map((parameter) => formatParameterSummary(parameter)),
+    ...node.metadata,
+  ];
+}
 
 function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
   const selectNode = () => {
@@ -91,7 +170,7 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
       <span className="architecture-node-kind">{data.kind}</span>
       <h4>{data.label}</h4>
       <ul>
-        {data.metadata.map((item) => (
+        {data.displayMetadata.map((item) => (
           <li key={item}>{item}</li>
         ))}
       </ul>
@@ -106,13 +185,37 @@ const nodeTypes: NodeTypes = {
 const canvasEdges: Edge[] = [];
 
 export function App() {
+  const [graphNodes, setGraphNodes] = useState<PrimitiveNode[]>(primitiveNodes);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const selectedNode =
-    primitiveNodes.find((node) => node.id === selectedNodeId) ?? null;
+    graphNodes.find((node) => node.id === selectedNodeId) ?? null;
+
+  const updateNodeParameter = (
+    nodeId: string,
+    parameterId: string,
+    nextValue: string | number | boolean,
+  ) => {
+    setGraphNodes((currentNodes) =>
+      currentNodes.map((node) => {
+        if (node.id !== nodeId) {
+          return node;
+        }
+
+        return {
+          ...node,
+          parameters: node.parameters.map((parameter) =>
+            parameter.id === parameterId
+              ? ({ ...parameter, value: nextValue } as PrimitiveNodeParameter)
+              : parameter,
+          ),
+        };
+      }),
+    );
+  };
 
   const canvasNodes: PrimitiveFlowNode[] = useMemo(
     () =>
-      primitiveNodes.map((node) => ({
+      graphNodes.map((node) => ({
         id: node.id,
         type: "primitive",
         position: node.position,
@@ -121,6 +224,8 @@ export function App() {
           label: node.label,
           kind: node.kind,
           metadata: node.metadata,
+          parameters: node.parameters,
+          displayMetadata: getDisplayMetadata(node),
           isSelected: selectedNodeId === node.id,
           onSelect: setSelectedNodeId,
         },
@@ -129,7 +234,7 @@ export function App() {
         selectable: true,
         draggable: false,
       })),
-    [selectedNodeId],
+    [graphNodes, selectedNodeId],
   );
 
   return (
@@ -203,10 +308,23 @@ export function App() {
                   </span>
                   <h4>{selectedNode.label}</h4>
                   <ul>
-                    {selectedNode.metadata.map((item) => (
+                    {getDisplayMetadata(selectedNode).map((item) => (
                       <li key={item}>{item}</li>
                     ))}
                   </ul>
+                  <div
+                    className="parameter-form"
+                    aria-label={`${selectedNode.label} parameters`}
+                  >
+                    {selectedNode.parameters.map((parameter) => (
+                      <ParameterControl
+                        key={parameter.id}
+                        nodeId={selectedNode.id}
+                        parameter={parameter}
+                        onChange={updateNodeParameter}
+                      />
+                    ))}
+                  </div>
                 </div>
               ) : (
                 <div className="inspector-empty">
@@ -248,5 +366,90 @@ export function App() {
         </section>
       </main>
     </div>
+  );
+}
+
+type ParameterControlProps = {
+  nodeId: string;
+  parameter: PrimitiveNodeParameter;
+  onChange: (
+    nodeId: string,
+    parameterId: string,
+    nextValue: string | number | boolean,
+  ) => void;
+};
+
+function ParameterControl({
+  nodeId,
+  parameter,
+  onChange,
+}: ParameterControlProps) {
+  if (parameter.type === "boolean") {
+    return (
+      <label className="parameter-control parameter-control-checkbox">
+        <span>{parameter.label}</span>
+        <input
+          type="checkbox"
+          checked={parameter.value}
+          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+            onChange(nodeId, parameter.id, event.target.checked)
+          }
+        />
+      </label>
+    );
+  }
+
+  if (parameter.type === "number") {
+    return (
+      <label className="parameter-control">
+        <span>{parameter.label}</span>
+        <input
+          type="number"
+          min={parameter.min}
+          step={parameter.step}
+          value={parameter.value}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            const nextValue = Number(event.target.value);
+
+            if (Number.isFinite(nextValue)) {
+              onChange(nodeId, parameter.id, nextValue);
+            }
+          }}
+        />
+      </label>
+    );
+  }
+
+  if (parameter.type === "select") {
+    return (
+      <label className="parameter-control">
+        <span>{parameter.label}</span>
+        <select
+          value={parameter.value}
+          onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+            onChange(nodeId, parameter.id, event.target.value)
+          }
+        >
+          {parameter.options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+
+  return (
+    <label className="parameter-control">
+      <span>{parameter.label}</span>
+      <input
+        type="text"
+        value={parameter.value}
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          onChange(nodeId, parameter.id, event.target.value)
+        }
+      />
+    </label>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -258,7 +258,7 @@ h4 {
 
 .graph-canvas {
   position: relative;
-  min-height: 660px;
+  min-height: 820px;
   overflow: hidden;
   background:
     linear-gradient(90deg, rgb(15 143 125 / 5%) 1px, transparent 1px),
@@ -278,7 +278,7 @@ h4 {
 }
 
 .graph-canvas .react-flow__node.architecture-flow-node {
-  width: 214px;
+  width: 228px;
   background: transparent;
   border: 0;
   box-shadow: none;
@@ -288,7 +288,7 @@ h4 {
 .architecture-node {
   display: grid;
   gap: 10px;
-  height: 132px;
+  height: 156px;
   width: 100%;
   align-content: start;
   text-align: left;
@@ -367,6 +367,57 @@ h4 {
   font-weight: 650;
   line-height: 1.3;
   list-style: none;
+}
+
+.parameter-form {
+  display: grid;
+  gap: 10px;
+  padding-top: 4px;
+}
+
+.parameter-control {
+  display: grid;
+  gap: 6px;
+}
+
+.parameter-control span {
+  color: var(--ink-muted);
+  font-size: 0.75rem;
+  font-weight: 740;
+  text-transform: uppercase;
+}
+
+.parameter-control input,
+.parameter-control select {
+  width: 100%;
+  min-height: 38px;
+  padding: 0 10px;
+  color: var(--ink);
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+.parameter-control input:focus,
+.parameter-control select:focus {
+  border-color: rgb(15 143 125 / 62%);
+  outline: 3px solid rgb(15 143 125 / 16%);
+}
+
+.parameter-control-checkbox {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 38px;
+}
+
+.parameter-control-checkbox input {
+  width: 18px;
+  min-height: 18px;
+  padding: 0;
+  accent-color: var(--accent);
 }
 
 .inspector-empty {
@@ -468,7 +519,7 @@ h4 {
   }
 
   .graph-canvas {
-    min-height: 660px;
+    min-height: 820px;
   }
 
   .canvas-empty-state {


### PR DESCRIPTION
## Summary

- Add structured primitive node parameters for the initial Phase 1 nodes.
- Render controlled inspector inputs for editable text, number, checkbox, and select parameters.
- Keep parameter values in in-memory graph state and mirror updated summaries on the canvas node cards.
- Adjust node/card spacing so expanded parameter summaries remain readable.

## Linked issue

Closes #8

## Verification

Automated:

- [x] `pnpm test` - passed, 6 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm format:check` - passed.
- [x] `pnpm build` - passed.

Manual:

- [x] Selected `Neuron` and confirmed editable `Units` and `Bias` controls render in the inspector.
- [x] Changed `Dense / Linear` units from `128` to `256` and confirmed the inspector and canvas card both updated.
- [x] Changed `Activation` function from `GELU` to `ReLU` and confirmed the inspector and canvas card both updated.
- [x] Switched back to `Dense / Linear` and confirmed `Units: 256` remained associated with that node during the session.
- [x] Confirmed node selection and inspector switching still work.

## Screenshots / video

Screenshot captured locally at `output/playwright/issue-8-parameter-editing.png`.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- Parameter edits are intentionally in-memory only; persistence remains out of scope for #8 and is covered by later roadmap work.
