### PR TITLE
[codex] Validate basic invalid connections

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -139,6 +139,38 @@ describe("App shell", () => {
     expect(screen.getByText("Neuron -> Activation")).toBeInTheDocument();
   });
 
+  it("rejects duplicate connections with clear feedback", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+    const connectionList = screen.getByLabelText(/graph connections/i);
+
+    expect(
+      within(connectionList).getAllByText("Tensor -> Neuron"),
+    ).toHaveLength(1);
+    expect(
+      screen.getByText(/that connection already exists/i),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects connections into the tensor input node with clear feedback", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from neuron/i));
+    fireEvent.click(screen.getByLabelText(/connect neuron to tensor/i));
+
+    expect(screen.queryByText("Neuron -> Tensor")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /tensor is an input node and cannot receive connections/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("keeps node selection and inspector behavior after connections are created", () => {
     render(<App />);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import {
   Activity,
+  AlertTriangle,
   Boxes,
   CircuitBoard,
   FlaskConical,
@@ -71,6 +72,10 @@ type GraphConnection = {
   source: string;
   target: string;
 };
+
+type ConnectionValidationResult =
+  | { isValid: true }
+  | { isValid: false; message: string };
 
 const workspaceItems = [
   { label: "Project", value: "Untitled graph" },
@@ -169,6 +174,51 @@ function getDisplayMetadata(node: PrimitiveNode) {
   ];
 }
 
+function validateGraphConnection(
+  sourceId: string,
+  targetId: string,
+  nodes: PrimitiveNode[],
+  connections: GraphConnection[],
+): ConnectionValidationResult {
+  const sourceNode = nodes.find((node) => node.id === sourceId);
+  const targetNode = nodes.find((node) => node.id === targetId);
+
+  if (!sourceNode || !targetNode) {
+    return {
+      isValid: false,
+      message: "Choose two existing nodes before creating a connection.",
+    };
+  }
+
+  if (sourceId === targetId) {
+    return {
+      isValid: false,
+      message: `${sourceNode.label} cannot connect to itself.`,
+    };
+  }
+
+  const connectionExists = connections.some(
+    (connection) =>
+      connection.source === sourceId && connection.target === targetId,
+  );
+
+  if (connectionExists) {
+    return {
+      isValid: false,
+      message: "That connection already exists.",
+    };
+  }
+
+  if (targetNode.kind === "Data") {
+    return {
+      isValid: false,
+      message: `${targetNode.label} is an input node and cannot receive connections.`,
+    };
+  }
+
+  return { isValid: true };
+}
+
 function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
   const selectNode = () => {
     data.onSelect(data.id);
@@ -265,6 +315,9 @@ export function App() {
   const [graphConnections, setGraphConnections] = useState<GraphConnection[]>(
     [],
   );
+  const [connectionFeedback, setConnectionFeedback] = useState<string | null>(
+    null,
+  );
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
     null,
@@ -299,28 +352,31 @@ export function App() {
 
   const addGraphConnection = useCallback(
     (sourceId: string, targetId: string) => {
-      setGraphConnections((currentConnections) => {
-        const connectionExists = currentConnections.some(
-          (connection) =>
-            connection.source === sourceId && connection.target === targetId,
-        );
+      const validation = validateGraphConnection(
+        sourceId,
+        targetId,
+        graphNodes,
+        graphConnections,
+      );
 
-        if (connectionExists) {
-          return currentConnections;
-        }
+      if (!validation.isValid) {
+        setConnectionFeedback(validation.message);
+        setConnectionSourceId(null);
+        return;
+      }
 
-        return [
-          ...currentConnections,
-          {
-            id: `connection-${sourceId}-${targetId}`,
-            source: sourceId,
-            target: targetId,
-          },
-        ];
-      });
+      setGraphConnections([
+        ...graphConnections,
+        {
+          id: `connection-${sourceId}-${targetId}`,
+          source: sourceId,
+          target: targetId,
+        },
+      ]);
+      setConnectionFeedback(null);
       setConnectionSourceId(null);
     },
-    [],
+    [graphConnections, graphNodes],
   );
 
   const completeGraphConnection = useCallback(
@@ -552,6 +608,13 @@ export function App() {
                 {canvasEdges.map((edge) => (
                   <span key={edge.id}>{edge.label}</span>
                 ))}
+              </div>
+            ) : null}
+
+            {connectionFeedback ? (
+              <div className="connection-feedback" role="alert">
+                <AlertTriangle size={16} aria-hidden="true" />
+                <span>{connectionFeedback}</span>
               </div>
             ) : null}
           </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -424,6 +424,33 @@ h4 {
   line-height: 1.25;
 }
 
+.connection-feedback {
+  position: fixed;
+  left: max(16px, env(safe-area-inset-left));
+  right: max(16px, env(safe-area-inset-right));
+  bottom: max(16px, env(safe-area-inset-bottom));
+  z-index: 20;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+  max-width: 520px;
+  padding: 10px 12px;
+  color: #7a3f00;
+  background: rgb(255 248 235 / 94%);
+  border: 1px solid rgb(199 123 23 / 34%);
+  border-radius: 8px;
+  box-shadow: 0 12px 28px rgb(23 33 31 / 10%);
+  font-size: 0.84rem;
+  font-weight: 720;
+  line-height: 1.3;
+  pointer-events: none;
+}
+
+.connection-feedback svg {
+  margin-top: 1px;
+}
+
 .inspector-details {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary

- Defines Phase 1 connection validation rules for duplicate connections, self-connections, missing nodes, and connections into the `Tensor` data input node.
- Rejects invalid connections before they enter graph state and clears the active connection source.
- Shows clear viewport-visible feedback for rejected connections.
- Adds focused regression coverage for duplicate rejection and input-node rejection.

## Linked issue

Closes #10

## Verification

Automated:

- [x] `pnpm test` - passed, 1 test file / 10 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed, production bundle built successfully.
- [x] `pnpm exec prettier --check src/App.tsx src/App.test.tsx src/styles.css` - passed for touched files.
- [x] `git diff --check` - passed.

Manual:

- [x] Opened the app at `http://127.0.0.1:1420/` in the in-app browser.
- [x] Created a valid `Tensor -> Neuron` connection and confirmed it renders.
- [x] Tried creating `Tensor -> Neuron` again and confirmed the duplicate is rejected with `That connection already exists.`
- [x] Tried creating `Neuron -> Tensor` and confirmed it is rejected with `Tensor is an input node and cannot receive connections.`
- [x] Confirmed the rejection feedback is visible in the current viewport after scrolling the canvas.
- [x] Confirmed existing valid connections and inspector behavior still work.
- [x] Checked browser console errors after manual verification; none were reported by the app.

## Screenshots / video

UI screenshots were captured during manual verification in the Codex app/in-app browser for:

- Duplicate-connection rejection feedback.
- `Tensor` input-node rejection feedback.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- `pnpm format:check` for the entire repository still reports a pre-existing formatting warning in `docs/superpowers/plans/2026-05-01-milestone-ux-ui-hardening.md`, which is unrelated to this issue and was left untouched.
- The PR is opened as draft for product-owner review.
