### PR TITLE
[codex] Add project import/export

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { App } from "./App";
@@ -156,5 +162,159 @@ describe("App shell", () => {
     expect(
       within(inspector).getByRole("spinbutton", { name: /units/i }),
     ).toHaveValue(1);
+  });
+
+  it("exports a minimal project with edited parameters and connections", async () => {
+    const originalCreateObjectUrl = URL.createObjectURL;
+    const originalRevokeObjectUrl = URL.revokeObjectURL;
+    const originalAnchorClick = HTMLAnchorElement.prototype.click;
+    let exportedProject = "";
+
+    URL.createObjectURL = (object: Blob) => {
+      const reader = new FileReader();
+
+      reader.addEventListener("load", () => {
+        exportedProject = String(reader.result);
+      });
+      reader.readAsText(object);
+
+      return "blob:dl-graph-studio-project";
+    };
+    URL.revokeObjectURL = () => {};
+    HTMLAnchorElement.prototype.click = () => {};
+
+    try {
+      render(<App />);
+
+      fireEvent.click(screen.getByLabelText(/dense \/ linear primitive node/i));
+      fireEvent.change(screen.getByRole("spinbutton", { name: /units/i }), {
+        target: { value: "256" },
+      });
+      fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+      fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+      fireEvent.click(screen.getByRole("button", { name: /export project/i }));
+
+      await waitFor(() => expect(exportedProject).not.toBe(""));
+
+      const project = JSON.parse(exportedProject);
+
+      expect(project).toMatchObject({
+        version: 1,
+        nodes: expect.arrayContaining([
+          expect.objectContaining({
+            id: "dense-linear",
+            parameters: expect.arrayContaining([
+              expect.objectContaining({ id: "units", value: 256 }),
+            ]),
+            position: { x: 96, y: 724 },
+          }),
+        ]),
+        connections: [
+          {
+            id: "connection-tensor-neuron",
+            source: "tensor",
+            target: "neuron",
+          },
+        ],
+      });
+    } finally {
+      URL.createObjectURL = originalCreateObjectUrl;
+      URL.revokeObjectURL = originalRevokeObjectUrl;
+      HTMLAnchorElement.prototype.click = originalAnchorClick;
+    }
+  });
+
+  it("imports a saved project after reset and restores parameters and connections", async () => {
+    render(<App />);
+
+    const savedProject = {
+      version: 1,
+      nodes: [
+        {
+          id: "tensor",
+          label: "Tensor",
+          kind: "Data",
+          metadata: ["Role: data carrier"],
+          parameters: [
+            { id: "shape", label: "Shape", type: "text", value: "batch, 32" },
+          ],
+          position: { x: 96, y: 64 },
+        },
+        {
+          id: "neuron",
+          label: "Neuron",
+          kind: "Foundation",
+          metadata: ["Lowest exposed primitive", "Parameters: weights + bias"],
+          parameters: [
+            {
+              id: "units",
+              label: "Units",
+              type: "number",
+              value: 4,
+              min: 1,
+              step: 1,
+            },
+            { id: "bias", label: "Bias", type: "boolean", value: false },
+          ],
+          position: { x: 96, y: 284 },
+        },
+      ],
+      connections: [
+        {
+          id: "connection-tensor-neuron",
+          source: "tensor",
+          target: "neuron",
+        },
+      ],
+    };
+
+    fireEvent.click(screen.getByLabelText(/dense \/ linear primitive node/i));
+    fireEvent.change(screen.getByRole("spinbutton", { name: /units/i }), {
+      target: { value: "512" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reset project/i }));
+    fireEvent.change(screen.getByLabelText(/import project/i), {
+      target: {
+        files: [
+          new File([JSON.stringify(savedProject)], "saved.dlgraph.json", {
+            type: "application/json",
+          }),
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/project loaded/i)).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByLabelText(/neuron primitive node/i));
+
+    expect(screen.getByText("Tensor -> Neuron")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: /units/i })).toHaveValue(4);
+    expect(screen.getByRole("checkbox", { name: /bias/i })).not.toBeChecked();
+  });
+
+  it("keeps the current graph when imported project data is invalid", async () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/dense \/ linear primitive node/i));
+    fireEvent.change(screen.getByRole("spinbutton", { name: /units/i }), {
+      target: { value: "384" },
+    });
+    fireEvent.change(screen.getByLabelText(/import project/i), {
+      target: {
+        files: [
+          new File(["not valid json"], "broken.dlgraph.json", {
+            type: "application/json",
+          }),
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not load project/i)).toBeInTheDocument(),
+    );
+
+    expect(screen.getByRole("spinbutton", { name: /units/i })).toHaveValue(384);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,14 @@ import {
   Activity,
   Boxes,
   CircuitBoard,
+  Download,
   FlaskConical,
   Folder,
   Info,
   Link2,
   PanelLeft,
+  RotateCcw,
+  Upload,
   X,
 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
@@ -27,50 +30,16 @@ import type {
 } from "@xyflow/react";
 
 import "@xyflow/react/dist/style.css";
-
-type PrimitiveNodeParameter =
-  | {
-      id: string;
-      label: string;
-      type: "number";
-      value: number;
-      min?: number;
-      step?: number;
-    }
-  | {
-      id: string;
-      label: string;
-      type: "select";
-      value: string;
-      options: string[];
-    }
-  | {
-      id: string;
-      label: string;
-      type: "text";
-      value: string;
-    }
-  | {
-      id: string;
-      label: string;
-      type: "boolean";
-      value: boolean;
-    };
-
-type PrimitiveNode = {
-  id: string;
-  label: string;
-  kind: string;
-  metadata: string[];
-  parameters: PrimitiveNodeParameter[];
-  position: { x: number; y: number };
-};
-
-type GraphConnection = {
-  id: string;
-  source: string;
-  target: string;
-};
+import {
+  createProjectFile,
+  parseProjectFileContent,
+  serializeProjectFile,
+} from "./projectFile";
+import type {
+  GraphConnection,
+  PrimitiveNode,
+  PrimitiveNodeParameter,
+} from "./projectFile";
 
 const workspaceItems = [
   { label: "Project", value: "Untitled graph" },
@@ -153,6 +122,19 @@ type PrimitiveNodeData = Omit<PrimitiveNode, "position"> & {
   displayMetadata: string[];
 };
 type PrimitiveFlowNode = Node<PrimitiveNodeData, "primitive">;
+type ProjectStatus = {
+  kind: "neutral" | "success" | "error";
+  message: string;
+};
+
+function createInitialGraphNodes() {
+  return primitiveNodes.map((node) => ({
+    ...node,
+    metadata: [...node.metadata],
+    parameters: node.parameters.map((parameter) => ({ ...parameter })),
+    position: { ...node.position },
+  }));
+}
 
 function formatParameterSummary(parameter: PrimitiveNodeParameter) {
   if (parameter.type === "boolean") {
@@ -167,6 +149,20 @@ function getDisplayMetadata(node: PrimitiveNode) {
     ...node.parameters.map((parameter) => formatParameterSummary(parameter)),
     ...node.metadata,
   ];
+}
+
+function readProjectFile(file: File) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.addEventListener("load", () => {
+      resolve(String(reader.result ?? ""));
+    });
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error("Project file could not be read."));
+    });
+    reader.readAsText(file);
+  });
 }
 
 function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
@@ -261,7 +257,9 @@ const nodeTypes: NodeTypes = {
 };
 
 export function App() {
-  const [graphNodes, setGraphNodes] = useState<PrimitiveNode[]>(primitiveNodes);
+  const [graphNodes, setGraphNodes] = useState<PrimitiveNode[]>(
+    createInitialGraphNodes,
+  );
   const [graphConnections, setGraphConnections] = useState<GraphConnection[]>(
     [],
   );
@@ -269,6 +267,10 @@ export function App() {
   const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
     null,
   );
+  const [projectStatus, setProjectStatus] = useState<ProjectStatus>({
+    kind: "neutral",
+    message: "Export or import a local project file.",
+  });
   const selectedNode =
     graphNodes.find((node) => node.id === selectedNodeId) ?? null;
   const connectionSource =
@@ -344,6 +346,71 @@ export function App() {
     },
     [addGraphConnection],
   );
+
+  const resetProject = () => {
+    setGraphNodes(createInitialGraphNodes());
+    setGraphConnections([]);
+    setSelectedNodeId(null);
+    setConnectionSourceId(null);
+    setProjectStatus({
+      kind: "neutral",
+      message: "Project reset to the default graph.",
+    });
+  };
+
+  const exportProject = () => {
+    const project = createProjectFile(graphNodes, graphConnections);
+    const blob = new Blob([serializeProjectFile(project)], {
+      type: "application/json",
+    });
+    const downloadUrl = URL.createObjectURL(blob);
+    const downloadLink = document.createElement("a");
+
+    downloadLink.href = downloadUrl;
+    downloadLink.download = "untitled-graph.dlgraph.json";
+    downloadLink.click();
+    URL.revokeObjectURL(downloadUrl);
+    setProjectStatus({
+      kind: "success",
+      message: "Project exported.",
+    });
+  };
+
+  const importProject = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+
+    if (!file) {
+      return;
+    }
+
+    try {
+      const result = parseProjectFileContent(await readProjectFile(file));
+
+      if (!result.ok) {
+        setProjectStatus({
+          kind: "error",
+          message: `Could not load project. ${result.message}`,
+        });
+        return;
+      }
+
+      setGraphNodes(result.project.nodes);
+      setGraphConnections(result.project.connections);
+      setSelectedNodeId(null);
+      setConnectionSourceId(null);
+      setProjectStatus({
+        kind: "success",
+        message: "Project loaded.",
+      });
+    } catch {
+      setProjectStatus({
+        kind: "error",
+        message: "Could not load project. The file could not be read.",
+      });
+    } finally {
+      event.target.value = "";
+    }
+  };
 
   const canvasNodes: PrimitiveFlowNode[] = useMemo(
     () =>
@@ -476,6 +543,29 @@ export function App() {
                   </div>
                 ))}
               </dl>
+              <div className="project-file-actions">
+                <button type="button" onClick={exportProject}>
+                  <Download size={15} aria-hidden="true" />
+                  <span>Export project</span>
+                </button>
+                <label className="project-file-import">
+                  <Upload size={15} aria-hidden="true" />
+                  <span>Import project</span>
+                  <input
+                    aria-label="Import project"
+                    type="file"
+                    accept=".dlgraph.json,.json,application/json"
+                    onChange={importProject}
+                  />
+                </label>
+                <button type="button" onClick={resetProject}>
+                  <RotateCcw size={15} aria-hidden="true" />
+                  <span>Reset project</span>
+                </button>
+              </div>
+              <p className={`project-file-status ${projectStatus.kind}`}>
+                {projectStatus.message}
+              </p>
             </div>
 
             <aside className="workspace-panel" aria-label="Node inspector">

--- a/src/projectFile.ts
+++ b/src/projectFile.ts
@@ -1,0 +1,271 @@
+export type PrimitiveNodeParameter =
+  | {
+      id: string;
+      label: string;
+      type: "number";
+      value: number;
+      min?: number;
+      step?: number;
+    }
+  | {
+      id: string;
+      label: string;
+      type: "select";
+      value: string;
+      options: string[];
+    }
+  | {
+      id: string;
+      label: string;
+      type: "text";
+      value: string;
+    }
+  | {
+      id: string;
+      label: string;
+      type: "boolean";
+      value: boolean;
+    };
+
+export type PrimitiveNode = {
+  id: string;
+  label: string;
+  kind: string;
+  metadata: string[];
+  parameters: PrimitiveNodeParameter[];
+  position: { x: number; y: number };
+};
+
+export type GraphConnection = {
+  id: string;
+  source: string;
+  target: string;
+};
+
+export type ProjectFile = {
+  version: 1;
+  nodes: PrimitiveNode[];
+  connections: GraphConnection[];
+};
+
+type ParseProjectFileResult =
+  | { ok: true; project: ProjectFile }
+  | { ok: false; message: string };
+
+const PROJECT_FILE_VERSION = 1;
+
+export function createProjectFile(
+  nodes: PrimitiveNode[],
+  connections: GraphConnection[],
+): ProjectFile {
+  return {
+    version: PROJECT_FILE_VERSION,
+    nodes: nodes.map(cloneNode),
+    connections: connections.map((connection) => ({ ...connection })),
+  };
+}
+
+export function serializeProjectFile(project: ProjectFile) {
+  return `${JSON.stringify(project, null, 2)}\n`;
+}
+
+export function parseProjectFileContent(
+  content: string,
+): ParseProjectFileResult {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { ok: false, message: "Project file is not valid JSON." };
+  }
+
+  if (!isRecord(parsed)) {
+    return { ok: false, message: "Project file must be a JSON object." };
+  }
+
+  if (parsed.version !== PROJECT_FILE_VERSION) {
+    return { ok: false, message: "Project file version is not supported." };
+  }
+
+  if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.connections)) {
+    return {
+      ok: false,
+      message: "Project file must include nodes and connections.",
+    };
+  }
+
+  const nodes = parsed.nodes.map(parseNode);
+
+  if (nodes.some((node) => node === null)) {
+    return { ok: false, message: "Project file contains invalid nodes." };
+  }
+
+  const parsedNodes = nodes as PrimitiveNode[];
+  const nodeIds = new Set(parsedNodes.map((node) => node.id));
+  const connections = parsed.connections.map((connection) =>
+    parseConnection(connection, nodeIds),
+  );
+
+  if (connections.some((connection) => connection === null)) {
+    return {
+      ok: false,
+      message: "Project file contains invalid connections.",
+    };
+  }
+
+  return {
+    ok: true,
+    project: {
+      version: PROJECT_FILE_VERSION,
+      nodes: parsedNodes,
+      connections: connections as GraphConnection[],
+    },
+  };
+}
+
+function cloneNode(node: PrimitiveNode): PrimitiveNode {
+  return {
+    ...node,
+    metadata: [...node.metadata],
+    parameters: node.parameters.map((parameter) => ({ ...parameter })),
+    position: { ...node.position },
+  };
+}
+
+function parseNode(value: unknown): PrimitiveNode | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (
+    !isString(value.id) ||
+    !isString(value.label) ||
+    !isString(value.kind) ||
+    !isStringArray(value.metadata) ||
+    !Array.isArray(value.parameters) ||
+    !isPosition(value.position)
+  ) {
+    return null;
+  }
+
+  const parameters = value.parameters.map(parseParameter);
+
+  if (parameters.some((parameter) => parameter === null)) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    label: value.label,
+    kind: value.kind,
+    metadata: value.metadata,
+    parameters: parameters as PrimitiveNodeParameter[],
+    position: value.position,
+  };
+}
+
+function parseParameter(value: unknown): PrimitiveNodeParameter | null {
+  if (!isRecord(value) || !isString(value.id) || !isString(value.label)) {
+    return null;
+  }
+
+  if (value.type === "number") {
+    if (!isFiniteNumber(value.value)) {
+      return null;
+    }
+
+    return {
+      id: value.id,
+      label: value.label,
+      type: "number",
+      value: value.value,
+      min: isFiniteNumber(value.min) ? value.min : undefined,
+      step: isFiniteNumber(value.step) ? value.step : undefined,
+    };
+  }
+
+  if (value.type === "select") {
+    if (!isString(value.value) || !isStringArray(value.options)) {
+      return null;
+    }
+
+    return {
+      id: value.id,
+      label: value.label,
+      type: "select",
+      value: value.value,
+      options: value.options,
+    };
+  }
+
+  if (value.type === "text") {
+    if (!isString(value.value)) {
+      return null;
+    }
+
+    return {
+      id: value.id,
+      label: value.label,
+      type: "text",
+      value: value.value,
+    };
+  }
+
+  if (value.type === "boolean") {
+    if (typeof value.value !== "boolean") {
+      return null;
+    }
+
+    return {
+      id: value.id,
+      label: value.label,
+      type: "boolean",
+      value: value.value,
+    };
+  }
+
+  return null;
+}
+
+function parseConnection(
+  value: unknown,
+  nodeIds: Set<string>,
+): GraphConnection | null {
+  if (
+    !isRecord(value) ||
+    !isString(value.id) ||
+    !isString(value.source) ||
+    !isString(value.target) ||
+    !nodeIds.has(value.source) ||
+    !nodeIds.has(value.target)
+  ) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    source: value.source,
+    target: value.target,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isString);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isPosition(value: unknown): value is PrimitiveNode["position"] {
+  return isRecord(value) && isFiniteNumber(value.x) && isFiniteNumber(value.y);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -256,6 +256,67 @@ h4 {
   font-weight: 650;
 }
 
+.project-file-actions {
+  display: grid;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.project-file-actions button,
+.project-file-import {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  width: 100%;
+  padding: 0 10px;
+  color: var(--accent-strong);
+  background: rgb(15 143 125 / 9%);
+  border: 1px solid rgb(15 143 125 / 22%);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 740;
+  cursor: pointer;
+}
+
+.project-file-actions button:hover,
+.project-file-actions button:focus-visible,
+.project-file-import:hover,
+.project-file-import:focus-within {
+  background: rgb(15 143 125 / 14%);
+  outline: 3px solid rgb(15 143 125 / 14%);
+}
+
+.project-file-import {
+  position: relative;
+  overflow: hidden;
+}
+
+.project-file-import input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.project-file-status {
+  margin: 12px 0 0;
+  color: var(--ink-muted);
+  font-size: 0.82rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.project-file-status.success {
+  color: var(--accent-strong);
+}
+
+.project-file-status.error {
+  color: #a34712;
+}
+
 .graph-canvas {
   position: relative;
   min-height: 960px;


### PR DESCRIPTION
## Summary

- Adds a versioned minimal project JSON format for primitive nodes, parameters, positions, and connections.
- Adds Session panel controls to export a `.dlgraph.json`, import a saved project, and reset to the default graph.
- Rejects malformed or unsupported project files without crashing or overwriting the current graph.
- Merges latest `origin/main` to resolve PR conflicts while preserving the Phase 1 connection validation behavior.

## Linked issue

Closes #11

## Verification

Automated:

- [x] `pnpm test` - passed, 13/13 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `pnpm format:check` - passed.

Manual:

- [x] Opened the app at `http://localhost:1420`.
- [x] Confirmed `Export project`, `Import project`, and `Reset project` controls are visible in the Session panel.
- [x] Clicked `Export project` and confirmed the `Project exported.` status appeared.
- [x] Checked browser console errors after the export flow; none were reported.
- [x] Product owner reviewed the local behavior in the Codex thread and approved the import/export approach.

## Screenshots / video

- Screenshot captured locally at `output/playwright/issue-11-import-export-controls.png` showing the Session import/export controls and canvas state. The `output/playwright/` directory is gitignored, so the image is not committed in this PR.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- This intentionally uses browser import/export instead of Tauri filesystem APIs. The serializer/validator can be reused later if native desktop file dialogs are added.
- Invalid project data preserves the current graph and displays an error instead of crashing.
