### PR TITLE
[codex] Add composite node representation

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -34,6 +34,23 @@ describe("App shell", () => {
     expect(screen.queryByText("Convolution")).not.toBeInTheDocument();
   });
 
+  it("renders a visually distinct composite architecture node on the canvas", () => {
+    render(<App />);
+
+    const compositeNode = screen.getByLabelText(/dense block composite node/i);
+
+    expect(screen.getAllByTestId("architecture-node")).toHaveLength(4);
+    expect(screen.getAllByTestId("composite-node")).toHaveLength(1);
+    expect(compositeNode).toHaveClass("composite-node");
+    expect(within(compositeNode).getByText("Composite")).toBeInTheDocument();
+    expect(within(compositeNode).getByText("Dense Block")).toBeInTheDocument();
+    expect(
+      within(compositeNode).getByText(
+        "Members: Neuron, Activation, Dense / Linear",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("shows readable metadata for each primitive node before selection", () => {
     render(<App />);
 
@@ -55,8 +72,14 @@ describe("App shell", () => {
     expect(
       screen.getByRole("heading", { name: /inspector/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/no node selected/i)).toBeInTheDocument();
-    expect(screen.getByText(/select a primitive node/i)).toBeInTheDocument();
+    const inspector = screen.getByRole("complementary", {
+      name: /node inspector/i,
+    });
+
+    expect(
+      within(inspector).getByText(/no node selected/i),
+    ).toBeInTheDocument();
+    expect(within(inspector).getByText(/select a node/i)).toBeInTheDocument();
   });
 
   it("selects a primitive node and shows editable inspector details", () => {
@@ -88,6 +111,37 @@ describe("App shell", () => {
     expect(
       within(inspector).getByRole("checkbox", { name: /bias/i }),
     ).toBeChecked();
+  });
+
+  it("selects a composite node and shows basic inspector details", () => {
+    render(<App />);
+
+    const compositeNode = screen.getByLabelText(/dense block composite node/i);
+
+    fireEvent.click(compositeNode);
+
+    expect(compositeNode).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText(/neuron primitive node/i)).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    const inspector = screen.getByRole("complementary", {
+      name: /node inspector/i,
+    });
+
+    expect(
+      within(inspector).getByRole("heading", { name: /dense block/i }),
+    ).toBeInTheDocument();
+    expect(within(inspector).getByText("Composite")).toBeInTheDocument();
+    expect(
+      within(inspector).getByText(
+        "Members: Neuron, Activation, Dense / Linear",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(inspector).getByText("Role: reusable feed-forward block"),
+    ).toBeInTheDocument();
   });
 
   it("updates selected node parameters and keeps values associated with each node", () => {
@@ -239,6 +293,11 @@ describe("App shell", () => {
               expect.objectContaining({ id: "units", value: 256 }),
             ]),
             position: { x: 96, y: 724 },
+          }),
+          expect.objectContaining({
+            id: "dense-block",
+            type: "composite",
+            memberNodeIds: ["neuron", "activation", "dense-linear"],
           }),
         ]),
         connections: [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,8 @@ import {
   serializeProjectFile,
 } from "./projectFile";
 import type {
+  CompositeNode,
+  GraphNode,
   GraphConnection,
   PrimitiveNode,
   PrimitiveNodeParameter,
@@ -55,6 +57,7 @@ const workspaceItems = [
 const primitiveNodes: PrimitiveNode[] = [
   {
     id: "tensor",
+    type: "primitive",
     label: "Tensor",
     kind: "Data",
     metadata: ["Role: data carrier"],
@@ -65,6 +68,7 @@ const primitiveNodes: PrimitiveNode[] = [
   },
   {
     id: "neuron",
+    type: "primitive",
     label: "Neuron",
     kind: "Foundation",
     metadata: ["Lowest exposed primitive", "Parameters: weights + bias"],
@@ -83,6 +87,7 @@ const primitiveNodes: PrimitiveNode[] = [
   },
   {
     id: "activation",
+    type: "primitive",
     label: "Activation",
     kind: "Primitive",
     metadata: ["Role: nonlinear transform"],
@@ -99,6 +104,7 @@ const primitiveNodes: PrimitiveNode[] = [
   },
   {
     id: "dense-linear",
+    type: "primitive",
     label: "Dense / Linear",
     kind: "Built-in",
     metadata: ["Derived from neuron primitives"],
@@ -116,6 +122,19 @@ const primitiveNodes: PrimitiveNode[] = [
   },
 ];
 
+const compositeNodes: CompositeNode[] = [
+  {
+    id: "dense-block",
+    type: "composite",
+    label: "Dense Block",
+    kind: "Composite",
+    metadata: ["Role: reusable feed-forward block"],
+    parameters: [],
+    memberNodeIds: ["neuron", "activation", "dense-linear"],
+    position: { x: 332, y: 344 },
+  },
+];
+
 type PrimitiveNodeData = Omit<PrimitiveNode, "position"> & {
   isSelected: boolean;
   connectionSourceId: string | null;
@@ -127,16 +146,26 @@ type PrimitiveNodeData = Omit<PrimitiveNode, "position"> & {
   displayMetadata: string[];
 };
 type PrimitiveFlowNode = Node<PrimitiveNodeData, "primitive">;
+type CompositeNodeData = Omit<CompositeNode, "position"> & {
+  isSelected: boolean;
+  onSelect: (nodeId: string) => void;
+  displayMetadata: string[];
+};
+type CompositeFlowNode = Node<CompositeNodeData, "composite">;
+type GraphFlowNode = PrimitiveFlowNode | CompositeFlowNode;
 type ProjectStatus = {
   kind: "neutral" | "success" | "error";
   message: string;
 };
 
 function createInitialGraphNodes() {
-  return primitiveNodes.map((node) => ({
+  return [...primitiveNodes, ...compositeNodes].map((node) => ({
     ...node,
     metadata: [...node.metadata],
     parameters: node.parameters.map((parameter) => ({ ...parameter })),
+    ...(node.type === "composite"
+      ? { memberNodeIds: [...node.memberNodeIds] }
+      : {}),
     position: { ...node.position },
   }));
 }
@@ -149,7 +178,21 @@ function formatParameterSummary(parameter: PrimitiveNodeParameter) {
   return `${parameter.label}: ${parameter.value}`;
 }
 
-function getDisplayMetadata(node: PrimitiveNode) {
+function getCompositeMemberSummary(node: CompositeNode, nodes: GraphNode[]) {
+  const memberLabels = node.memberNodeIds.map(
+    (memberNodeId) =>
+      nodes.find((candidateNode) => candidateNode.id === memberNodeId)?.label ??
+      memberNodeId,
+  );
+
+  return `Members: ${memberLabels.join(", ")}`;
+}
+
+function getDisplayMetadata(node: GraphNode, nodes: GraphNode[]) {
+  if (node.type === "composite") {
+    return [getCompositeMemberSummary(node, nodes), ...node.metadata];
+  }
+
   return [
     ...node.parameters.map((parameter) => formatParameterSummary(parameter)),
     ...node.metadata,
@@ -173,7 +216,7 @@ function readProjectFile(file: File) {
 function validateGraphConnection(
   sourceId: string,
   targetId: string,
-  nodes: PrimitiveNode[],
+  nodes: GraphNode[],
   connections: GraphConnection[],
 ): ConnectionValidationResult {
   const sourceNode = nodes.find((node) => node.id === sourceId);
@@ -302,12 +345,49 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
   );
 }
 
+function CompositeNodeCard({ data }: NodeProps<CompositeFlowNode>) {
+  const selectNode = () => {
+    data.onSelect(data.id);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      selectNode();
+    }
+  };
+
+  return (
+    <article
+      className={`architecture-node composite-node${
+        data.isSelected ? " selected" : ""
+      }`}
+      data-testid="composite-node"
+      role="button"
+      tabIndex={0}
+      aria-pressed={data.isSelected}
+      aria-label={`${data.label} composite node`}
+      onClick={selectNode}
+      onKeyDown={handleKeyDown}
+    >
+      <span className="architecture-node-kind">{data.kind}</span>
+      <h4>{data.label}</h4>
+      <ul>
+        {data.displayMetadata.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
 const nodeTypes: NodeTypes = {
   primitive: PrimitiveNodeCard,
+  composite: CompositeNodeCard,
 };
 
 export function App() {
-  const [graphNodes, setGraphNodes] = useState<PrimitiveNode[]>(
+  const [graphNodes, setGraphNodes] = useState<GraphNode[]>(
     createInitialGraphNodes,
   );
   const [graphConnections, setGraphConnections] = useState<GraphConnection[]>(
@@ -468,32 +548,59 @@ export function App() {
     }
   };
 
-  const canvasNodes: PrimitiveFlowNode[] = useMemo(
+  const canvasNodes: GraphFlowNode[] = useMemo(
     () =>
-      graphNodes.map((node) => ({
-        id: node.id,
-        type: "primitive",
-        position: node.position,
-        data: {
+      graphNodes.map((node) => {
+        const commonNode = {
           id: node.id,
-          label: node.label,
-          kind: node.kind,
-          metadata: node.metadata,
-          parameters: node.parameters,
-          displayMetadata: getDisplayMetadata(node),
-          isSelected: selectedNodeId === node.id,
-          connectionSourceId,
-          connectionSourceLabel: connectionSource?.label ?? null,
-          onSelect: setSelectedNodeId,
-          onStartConnection: setConnectionSourceId,
-          onCancelConnection: () => setConnectionSourceId(null),
-          onCompleteConnection: completeGraphConnection,
-        },
-        className: "architecture-flow-node",
-        selected: selectedNodeId === node.id,
-        selectable: true,
-        draggable: false,
-      })),
+          position: node.position,
+          selected: selectedNodeId === node.id,
+          selectable: true,
+          draggable: false,
+        };
+
+        if (node.type === "composite") {
+          return {
+            ...commonNode,
+            type: "composite",
+            data: {
+              id: node.id,
+              type: node.type,
+              label: node.label,
+              kind: node.kind,
+              metadata: node.metadata,
+              parameters: node.parameters,
+              memberNodeIds: node.memberNodeIds,
+              displayMetadata: getDisplayMetadata(node, graphNodes),
+              isSelected: selectedNodeId === node.id,
+              onSelect: setSelectedNodeId,
+            },
+            className: "architecture-flow-node composite-flow-node",
+          };
+        }
+
+        return {
+          ...commonNode,
+          type: "primitive",
+          data: {
+            id: node.id,
+            type: node.type,
+            label: node.label,
+            kind: node.kind,
+            metadata: node.metadata,
+            parameters: node.parameters,
+            displayMetadata: getDisplayMetadata(node, graphNodes),
+            isSelected: selectedNodeId === node.id,
+            connectionSourceId,
+            connectionSourceLabel: connectionSource?.label ?? null,
+            onSelect: setSelectedNodeId,
+            onStartConnection: setConnectionSourceId,
+            onCancelConnection: () => setConnectionSourceId(null),
+            onCompleteConnection: completeGraphConnection,
+          },
+          className: "architecture-flow-node",
+        };
+      }),
     [
       completeGraphConnection,
       connectionSource?.label,
@@ -637,28 +744,32 @@ export function App() {
                   </span>
                   <h4>{selectedNode.label}</h4>
                   <ul>
-                    {getDisplayMetadata(selectedNode).map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
+                    {getDisplayMetadata(selectedNode, graphNodes).map(
+                      (item) => (
+                        <li key={item}>{item}</li>
+                      ),
+                    )}
                   </ul>
-                  <div
-                    className="parameter-form"
-                    aria-label={`${selectedNode.label} parameters`}
-                  >
-                    {selectedNode.parameters.map((parameter) => (
-                      <ParameterControl
-                        key={parameter.id}
-                        nodeId={selectedNode.id}
-                        parameter={parameter}
-                        onChange={updateNodeParameter}
-                      />
-                    ))}
-                  </div>
+                  {selectedNode.parameters.length > 0 ? (
+                    <div
+                      className="parameter-form"
+                      aria-label={`${selectedNode.label} parameters`}
+                    >
+                      {selectedNode.parameters.map((parameter) => (
+                        <ParameterControl
+                          key={parameter.id}
+                          nodeId={selectedNode.id}
+                          parameter={parameter}
+                          onChange={updateNodeParameter}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
               ) : (
                 <div className="inspector-empty">
                   <p>No node selected</p>
-                  <span>Select a primitive node on the canvas.</span>
+                  <span>Select a node on the canvas.</span>
                 </div>
               )}
             </aside>

--- a/src/projectFile.ts
+++ b/src/projectFile.ts
@@ -27,7 +27,7 @@ export type PrimitiveNodeParameter =
       value: boolean;
     };
 
-export type PrimitiveNode = {
+type BaseGraphNode = {
   id: string;
   label: string;
   kind: string;
@@ -35,6 +35,17 @@ export type PrimitiveNode = {
   parameters: PrimitiveNodeParameter[];
   position: { x: number; y: number };
 };
+
+export type PrimitiveNode = BaseGraphNode & {
+  type: "primitive";
+};
+
+export type CompositeNode = BaseGraphNode & {
+  type: "composite";
+  memberNodeIds: string[];
+};
+
+export type GraphNode = PrimitiveNode | CompositeNode;
 
 export type GraphConnection = {
   id: string;
@@ -44,7 +55,7 @@ export type GraphConnection = {
 
 export type ProjectFile = {
   version: 1;
-  nodes: PrimitiveNode[];
+  nodes: GraphNode[];
   connections: GraphConnection[];
 };
 
@@ -55,7 +66,7 @@ type ParseProjectFileResult =
 const PROJECT_FILE_VERSION = 1;
 
 export function createProjectFile(
-  nodes: PrimitiveNode[],
+  nodes: GraphNode[],
   connections: GraphConnection[],
 ): ProjectFile {
   return {
@@ -101,7 +112,7 @@ export function parseProjectFileContent(
     return { ok: false, message: "Project file contains invalid nodes." };
   }
 
-  const parsedNodes = nodes as PrimitiveNode[];
+  const parsedNodes = nodes as GraphNode[];
   const nodeIds = new Set(parsedNodes.map((node) => node.id));
   const connections = parsed.connections.map((connection) =>
     parseConnection(connection, nodeIds),
@@ -124,16 +135,25 @@ export function parseProjectFileContent(
   };
 }
 
-function cloneNode(node: PrimitiveNode): PrimitiveNode {
-  return {
+function cloneNode(node: GraphNode): GraphNode {
+  const clonedNode = {
     ...node,
     metadata: [...node.metadata],
     parameters: node.parameters.map((parameter) => ({ ...parameter })),
     position: { ...node.position },
   };
+
+  if (clonedNode.type === "composite") {
+    return {
+      ...clonedNode,
+      memberNodeIds: [...clonedNode.memberNodeIds],
+    };
+  }
+
+  return clonedNode;
 }
 
-function parseNode(value: unknown): PrimitiveNode | null {
+function parseNode(value: unknown): GraphNode | null {
   if (!isRecord(value)) {
     return null;
   }
@@ -155,7 +175,8 @@ function parseNode(value: unknown): PrimitiveNode | null {
     return null;
   }
 
-  return {
+  const nodeType = value.type ?? "primitive";
+  const baseNode = {
     id: value.id,
     label: value.label,
     kind: value.kind,
@@ -163,6 +184,23 @@ function parseNode(value: unknown): PrimitiveNode | null {
     parameters: parameters as PrimitiveNodeParameter[],
     position: value.position,
   };
+
+  if (nodeType === "primitive") {
+    return {
+      ...baseNode,
+      type: "primitive",
+    };
+  }
+
+  if (nodeType === "composite" && isStringArray(value.memberNodeIds)) {
+    return {
+      ...baseNode,
+      type: "composite",
+      memberNodeIds: value.memberNodeIds,
+    };
+  }
+
+  return null;
 }
 
 function parseParameter(value: unknown): PrimitiveNodeParameter | null {
@@ -266,6 +304,6 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function isPosition(value: unknown): value is PrimitiveNode["position"] {
+function isPosition(value: unknown): value is GraphNode["position"] {
   return isRecord(value) && isFiniteNumber(value.x) && isFiniteNumber(value.y);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -346,6 +346,10 @@ h4 {
   cursor: pointer;
 }
 
+.graph-canvas .react-flow__node.composite-flow-node {
+  width: 220px;
+}
+
 .architecture-node {
   display: grid;
   gap: 10px;
@@ -362,6 +366,17 @@ h4 {
   box-shadow: 0 14px 30px rgb(23 33 31 / 14%);
   outline: none;
   cursor: pointer;
+}
+
+.architecture-node.composite-node {
+  height: 180px;
+  background:
+    linear-gradient(135deg, rgb(199 123 23 / 12%), transparent 42%), #fffdf8;
+  border-color: rgb(199 123 23 / 46%);
+  border-left-color: var(--signal);
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 70%),
+    0 18px 36px rgb(23 33 31 / 16%);
 }
 
 .architecture-node-shell {
@@ -390,6 +405,22 @@ h4 {
 
 .architecture-node.connection-target {
   border-color: rgb(199 123 23 / 58%);
+}
+
+.architecture-node.composite-node:hover,
+.architecture-node.composite-node:focus-visible,
+.architecture-node.composite-node.selected {
+  border-color: rgb(199 123 23 / 72%);
+  box-shadow:
+    0 0 0 3px rgb(199 123 23 / 22%),
+    inset 0 0 0 1px rgb(255 255 255 / 82%),
+    0 20px 38px rgb(23 33 31 / 20%);
+}
+
+.composite-node .architecture-node-kind {
+  color: #7a3f00;
+  background: rgb(199 123 23 / 13%);
+  border-color: rgb(199 123 23 / 24%);
 }
 
 .architecture-node-kind {
@@ -422,6 +453,7 @@ h4 {
   font-weight: 650;
   line-height: 1.25;
   list-style: none;
+  overflow-wrap: anywhere;
 }
 
 .architecture-node-handle {


### PR DESCRIPTION
## Summary

- Added a minimal graph node union so project data can represent primitive and composite nodes.
- Added a default `Dense Block` composite node with member references to the existing primitive nodes.
- Rendered the composite node with distinct canvas styling and inspector details while preserving primitive parameter editing and connection behavior.
- Added focused test coverage for composite rendering, selection/inspector details, and project export shape.

## Linked issue

Closes #12

## Verification

Automated:

- [x] `pnpm test` - passed, 15 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `pnpm format:check` - passed.
- [x] `git diff --check` - passed.

Manual:

- [x] Opened `http://127.0.0.1:1420/` in the Codex in-app browser and confirmed the amber `Dense Block` composite node renders fully on the canvas.
- [x] Selected `Dense Block` and confirmed the inspector shows `Composite`, its member list, and role metadata.
- [x] Selected the primitive `Neuron` node afterward and confirmed primitive inspector controls still show editable `Units` and `Bias` fields.

## Screenshots / video

- Manual screenshot was captured during Codex in-app browser verification. It is not committed because `output/playwright/` is ignored by the repository.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- Composite nodes are represented and selectable, but nested graph editing, reusable component behavior, runtime execution, and advanced composite validation remain out of scope for this issue.
