### PR TITLE
[codex] Delete individual graph connections

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -199,6 +199,31 @@ describe("App shell", () => {
     expect(screen.getByText("Neuron -> Activation")).toBeInTheDocument();
   });
 
+  it("deletes one chosen connection while preserving nodes and other connections", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+    fireEvent.click(screen.getByLabelText(/start connection from neuron/i));
+    fireEvent.click(screen.getByLabelText(/connect neuron to activation/i));
+
+    fireEvent.click(screen.getByLabelText(/delete connection tensor to neuron/i));
+
+    const connectionList = screen.getByLabelText(/graph connections/i);
+
+    expect(
+      within(connectionList).queryByText("Tensor -> Neuron"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(connectionList).getByText("Neuron -> Activation"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("alert"),
+    ).toHaveTextContent(/tensor -> neuron deleted/i);
+    expect(screen.getByLabelText(/tensor primitive node/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/neuron primitive node/i)).toBeInTheDocument();
+  });
+
   it("rejects duplicate connections with clear feedback", () => {
     render(<App />);
 
@@ -250,7 +275,7 @@ describe("App shell", () => {
     ).toHaveValue(1);
   });
 
-  it("exports a minimal project with edited parameters and connections", async () => {
+  it("exports a minimal project with edited parameters and remaining connections after deletion", async () => {
     const originalCreateObjectUrl = URL.createObjectURL;
     const originalRevokeObjectUrl = URL.revokeObjectURL;
     const originalAnchorClick = HTMLAnchorElement.prototype.click;
@@ -278,6 +303,11 @@ describe("App shell", () => {
       });
       fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
       fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+      fireEvent.click(screen.getByLabelText(/start connection from neuron/i));
+      fireEvent.click(screen.getByLabelText(/connect neuron to activation/i));
+      fireEvent.click(
+        screen.getByLabelText(/delete connection tensor to neuron/i),
+      );
       fireEvent.click(screen.getByRole("button", { name: /export project/i }));
 
       await waitFor(() => expect(exportedProject).not.toBe(""));
@@ -302,9 +332,9 @@ describe("App shell", () => {
         ]),
         connections: [
           {
-            id: "connection-tensor-neuron",
-            source: "tensor",
-            target: "neuron",
+            id: "connection-neuron-activation",
+            source: "neuron",
+            target: "activation",
           },
         ],
       });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
   Link2,
   PanelLeft,
   RotateCcw,
+  Trash2,
   Upload,
   X,
 } from "lucide-react";
@@ -258,6 +259,22 @@ function validateGraphConnection(
   return { isValid: true };
 }
 
+function getGraphConnectionLabel(
+  connection: GraphConnection,
+  nodes: GraphNode[],
+) {
+  const sourceNode = nodes.find((node) => node.id === connection.source);
+  const targetNode = nodes.find((node) => node.id === connection.target);
+
+  return `${sourceNode?.label ?? connection.source} -> ${
+    targetNode?.label ?? connection.target
+  }`;
+}
+
+function getDeleteConnectionLabel(connectionLabel: string) {
+  return `Delete connection ${connectionLabel.replace(" -> ", " to ")}`;
+}
+
 function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
   const selectNode = () => {
     data.onSelect(data.id);
@@ -483,6 +500,29 @@ export function App() {
     [addGraphConnection],
   );
 
+  const deleteGraphConnection = useCallback(
+    (connectionId: string) => {
+      const connection = graphConnections.find(
+        (candidateConnection) => candidateConnection.id === connectionId,
+      );
+
+      if (!connection) {
+        return;
+      }
+
+      const connectionLabel = getGraphConnectionLabel(connection, graphNodes);
+
+      setGraphConnections(
+        graphConnections.filter(
+          (candidateConnection) => candidateConnection.id !== connectionId,
+        ),
+      );
+      setConnectionSourceId(null);
+      setConnectionFeedback(`${connectionLabel} deleted.`);
+    },
+    [graphConnections, graphNodes],
+  );
+
   const resetProject = () => {
     setGraphNodes(createInitialGraphNodes());
     setGraphConnections([]);
@@ -613,15 +653,7 @@ export function App() {
   const canvasEdges: Edge[] = useMemo(
     () =>
       graphConnections.map((connection) => {
-        const sourceNode = graphNodes.find(
-          (node) => node.id === connection.source,
-        );
-        const targetNode = graphNodes.find(
-          (node) => node.id === connection.target,
-        );
-        const label = `${sourceNode?.label ?? connection.source} -> ${
-          targetNode?.label ?? connection.target
-        }`;
+        const label = getGraphConnectionLabel(connection, graphNodes);
 
         return {
           id: connection.id,
@@ -806,9 +838,27 @@ export function App() {
 
             {canvasEdges.length > 0 ? (
               <div className="connection-list" aria-label="Graph connections">
-                {canvasEdges.map((edge) => (
-                  <span key={edge.id}>{edge.label}</span>
-                ))}
+                {graphConnections.map((connection) => {
+                  const connectionLabel = getGraphConnectionLabel(
+                    connection,
+                    graphNodes,
+                  );
+
+                  return (
+                    <div className="connection-list-item" key={connection.id}>
+                      <span>{connectionLabel}</span>
+                      <button
+                        type="button"
+                        className="connection-delete-button"
+                        aria-label={getDeleteConnectionLabel(connectionLabel)}
+                        title={getDeleteConnectionLabel(connectionLabel)}
+                        onClick={() => deleteGraphConnection(connection.id)}
+                      >
+                        <Trash2 size={13} aria-hidden="true" />
+                      </button>
+                    </div>
+                  );
+                })}
               </div>
             ) : null}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -507,14 +507,40 @@ h4 {
   border: 1px solid rgb(15 143 125 / 22%);
   border-radius: 8px;
   box-shadow: 0 12px 28px rgb(23 33 31 / 10%);
-  pointer-events: none;
+  pointer-events: auto;
 }
 
-.connection-list span {
+.connection-list-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 26px;
+  align-items: center;
+  gap: 8px;
+}
+
+.connection-list-item span {
   overflow-wrap: anywhere;
   font-size: 0.78rem;
   font-weight: 760;
   line-height: 1.25;
+}
+
+.connection-delete-button {
+  display: inline-grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  color: #8c2f1f;
+  background: rgb(255 255 255 / 86%);
+  border: 1px solid rgb(140 47 31 / 22%);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.connection-delete-button:hover,
+.connection-delete-button:focus-visible {
+  color: #ffffff;
+  background: #8c2f1f;
+  outline: 3px solid rgb(140 47 31 / 18%);
 }
 
 .connection-feedback {


### PR DESCRIPTION
## Summary

- Add a per-connection delete control to the canvas connection list.
- Remove only the selected connection from in-memory graph state and clear any active connection source.
- Keep export behavior tied to the current graph state so deleted connections stay absent and remaining connections persist.
- Add focused coverage for deleting one connection while preserving nodes and unrelated connections.

## Linked issue

Closes #26

## Verification

Automated:

- [x] `pnpm test` - passed, 16/16 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] Independent code review - no findings.

Manual:

- [x] Opened the app with Vite on `http://127.0.0.1:1421/`.
- [x] Created `Tensor -> Neuron` and `Neuron -> Activation`.
- [x] Deleted `Tensor -> Neuron` from the connection list.
- [x] Confirmed only `Neuron -> Activation` remained visible and the graph nodes stayed in place.
- [x] Confirmed browser console had 0 errors after the flow.

## Screenshots / video

- Screenshot captured locally at `output/playwright/issue-26-delete-connection.png` during manual verification. The `output/playwright/` directory is gitignored, so the image is not included in the diff.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- This stays scoped to deleting existing connections from the connection list. It does not add edge selection, bulk deletion, undo/redo, or canvas interaction redesign.
