### PR TITLE
[Roadmap]: Extract App project file workflow

### DIFF
--- a/docs/superpowers/plans/2026-05-04-extract-app-project-file-workflow.md
+++ b/docs/superpowers/plans/2026-05-04-extract-app-project-file-workflow.md
@@ -30,6 +30,7 @@
 ### Task 1: Add Hook Boundary Tests
 
 **Files:**
+
 - Create: `src/useProjectFileWorkflow.test.tsx`
 - Read: `src/projectFile.ts`
 
@@ -38,7 +39,13 @@
 Create `src/useProjectFileWorkflow.test.tsx` with this content:
 
 ```tsx
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
@@ -72,9 +79,7 @@ const editedNodes: GraphNode[] = [
     label: "Dense",
     kind: "Layer",
     metadata: ["Role: transform"],
-    parameters: [
-      { id: "units", label: "Units", type: "number", value: 128 },
-    ],
+    parameters: [{ id: "units", label: "Units", type: "number", value: 128 }],
     position: { x: 320, y: 96 },
   },
 ];
@@ -422,6 +427,7 @@ Expected: commit succeeds with only the new test file staged.
 ### Task 2: Implement `useProjectFileWorkflow`
 
 **Files:**
+
 - Create: `src/useProjectFileWorkflow.ts`
 - Test: `src/useProjectFileWorkflow.test.tsx`
 
@@ -579,11 +585,7 @@ export function useProjectFileWorkflow({
       setIsProjectActionsOpen(false);
       event.target.value = "";
     },
-    [
-      clearEditorProjectWorkflowState,
-      setGraphConnections,
-      setGraphNodes,
-    ],
+    [clearEditorProjectWorkflowState, setGraphConnections, setGraphNodes],
   );
 
   const resetProject = useCallback(() => {
@@ -639,6 +641,7 @@ Expected: commit succeeds with hook and adjusted tests.
 ### Task 3: Wire `App.tsx` To The Hook
 
 **Files:**
+
 - Modify: `src/App.tsx`
 - Test: `src/App.test.tsx`
 - Test: `src/App.nodeDrag.test.tsx`
@@ -743,7 +746,7 @@ onClick={() => fileInputRef.current?.click()}
 with:
 
 ```tsx
-onClick={openProjectImportPicker}
+onClick = { openProjectImportPicker };
 ```
 
 Keep the hidden input props unchanged except for using the hook-provided `fileInputRef` and `importProjectFile`.
@@ -784,6 +787,7 @@ Expected: commit succeeds with only `src/App.tsx` staged.
 ### Task 4: Full Verification And Cleanup
 
 **Files:**
+
 - Review: `src/App.tsx`
 - Review: `src/useProjectFileWorkflow.ts`
 - Review: `src/useProjectFileWorkflow.test.tsx`

--- a/docs/superpowers/plans/2026-05-04-extract-app-project-file-workflow.md
+++ b/docs/superpowers/plans/2026-05-04-extract-app-project-file-workflow.md
@@ -1,0 +1,880 @@
+# Extract App Project File Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the browser project import/export/reset workflow from `src/App.tsx` into a focused hook while preserving current behavior and fixing dragged-node cleanup on successful import/reset.
+
+**Architecture:** `src/projectFile.ts` remains the persisted project format and validation boundary. A new `src/useProjectFileWorkflow.ts` hook owns project action menu state, file input ref, project toast lifecycle, browser file reading, browser download side effects, and import/export/reset orchestration. `src/App.tsx` keeps graph/editor state, React Flow adapters, inspector behavior, drag behavior, connection behavior, and rendering.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, Vite, existing browser `File`, `FileReader`, `Blob`, and `URL` APIs.
+
+---
+
+## File Structure
+
+- Create `src/useProjectFileWorkflow.ts`
+  - Owns project workflow state and side effects.
+  - Exports `readTextFile` for focused unit coverage.
+  - Exports `useProjectFileWorkflow`.
+- Create `src/useProjectFileWorkflow.test.tsx`
+  - Tests the new hook through a small React harness instead of unrelated `App.tsx` rendering.
+- Modify `src/App.tsx`
+  - Remove project workflow state/effects/helpers from `App`.
+  - Import and call `useProjectFileWorkflow`.
+  - Wire existing topbar/menu/input/toast JSX to the hook return values.
+  - Pass `setDraggedNodeId(null)` cleanup into the hook for successful import/reset.
+- Keep `src/projectFile.ts` unchanged.
+
+---
+
+### Task 1: Add Hook Boundary Tests
+
+**Files:**
+- Create: `src/useProjectFileWorkflow.test.tsx`
+- Read: `src/projectFile.ts`
+
+- [ ] **Step 1: Create the failing hook test file**
+
+Create `src/useProjectFileWorkflow.test.tsx` with this content:
+
+```tsx
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { useProjectFileWorkflow } from "./useProjectFileWorkflow";
+import type { GraphConnection, GraphNode } from "./projectFile";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+const initialNodes: GraphNode[] = [
+  {
+    id: "tensor",
+    type: "primitive",
+    label: "Tensor",
+    kind: "Data",
+    metadata: ["Role: data carrier"],
+    parameters: [
+      { id: "shape", label: "Shape", type: "text", value: "dynamic" },
+    ],
+    position: { x: 96, y: 64 },
+  },
+];
+
+const editedNodes: GraphNode[] = [
+  {
+    id: "dense",
+    type: "primitive",
+    label: "Dense",
+    kind: "Layer",
+    metadata: ["Role: transform"],
+    parameters: [
+      { id: "units", label: "Units", type: "number", value: 128 },
+    ],
+    position: { x: 320, y: 96 },
+  },
+];
+
+const editedConnections: GraphConnection[] = [
+  { id: "connection-tensor-dense", source: "tensor", target: "dense" },
+];
+
+function createProjectContent(
+  nodes: GraphNode[] = editedNodes,
+  connections: GraphConnection[] = editedConnections,
+) {
+  return JSON.stringify({
+    version: 1,
+    nodes,
+    connections,
+  });
+}
+
+function WorkflowHarness({
+  initialGraphNodes = initialNodes,
+  initialGraphConnections = [],
+}: {
+  initialGraphNodes?: GraphNode[];
+  initialGraphConnections?: GraphConnection[];
+}) {
+  const [graphNodes, setGraphNodes] = useState(initialGraphNodes);
+  const [graphConnections, setGraphConnections] = useState(
+    initialGraphConnections,
+  );
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>("tensor");
+  const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
+    "tensor",
+  );
+  const [connectionFeedback, setConnectionFeedback] = useState<string | null>(
+    "Existing feedback",
+  );
+  const [draggedNodeId, setDraggedNodeId] = useState<string | null>("tensor");
+  const workflow = useProjectFileWorkflow({
+    graphNodes,
+    graphConnections,
+    setGraphNodes,
+    setGraphConnections,
+    createInitialGraphNodes: () =>
+      initialNodes.map((node) => ({ ...node, position: { ...node.position } })),
+    clearSelectedNode: () => setSelectedNodeId(null),
+    clearConnectionSource: () => setConnectionSourceId(null),
+    clearConnectionFeedback: () => setConnectionFeedback(null),
+    clearDraggedNode: () => setDraggedNodeId(null),
+  });
+
+  return (
+    <div>
+      <button type="button" onClick={workflow.toggleProjectActions}>
+        Toggle menu
+      </button>
+      <button type="button" onClick={workflow.openProjectImportPicker}>
+        Open import
+      </button>
+      <button type="button" onClick={workflow.exportProjectFile}>
+        Export
+      </button>
+      <button type="button" onClick={workflow.resetProject}>
+        Reset
+      </button>
+      <input
+        aria-label="Import project file"
+        ref={workflow.fileInputRef}
+        type="file"
+        onChange={workflow.importProjectFile}
+      />
+      <output aria-label="menu state">
+        {workflow.isProjectActionsOpen ? "open" : "closed"}
+      </output>
+      <output aria-label="toast">{workflow.projectToast ?? "none"}</output>
+      <output aria-label="nodes">
+        {graphNodes.map((node) => node.id).join(",")}
+      </output>
+      <output aria-label="connections">
+        {graphConnections.map((connection) => connection.id).join(",")}
+      </output>
+      <output aria-label="selected">{selectedNodeId ?? "none"}</output>
+      <output aria-label="connection source">
+        {connectionSourceId ?? "none"}
+      </output>
+      <output aria-label="connection feedback">
+        {connectionFeedback ?? "none"}
+      </output>
+      <output aria-label="dragged">{draggedNodeId ?? "none"}</output>
+    </div>
+  );
+}
+
+describe("useProjectFileWorkflow", () => {});
+```
+
+- [ ] **Step 2: Add the export workflow test**
+
+Replace the empty `describe("useProjectFileWorkflow", () => {});` block with this opening block and test:
+
+```tsx
+describe("useProjectFileWorkflow", () => {
+  it("exports the current project and closes the project actions menu", () => {
+    const OriginalBlob = globalThis.Blob;
+    const blobParts: BlobPart[][] = [];
+    const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(
+      URL,
+      "createObjectURL",
+    );
+    const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(
+      URL,
+      "revokeObjectURL",
+    );
+    const createObjectURL = vi.fn(() => "blob:project-file");
+    const revokeObjectURL = vi.fn();
+
+    vi.stubGlobal(
+      "Blob",
+      vi.fn((parts?: BlobPart[], options?: BlobPropertyBag) => {
+        blobParts.push(parts ?? []);
+        return new OriginalBlob(parts, options);
+      }),
+    );
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    try {
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+        () => undefined,
+      );
+
+      render(
+        <WorkflowHarness
+          initialGraphNodes={editedNodes}
+          initialGraphConnections={editedConnections}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+      fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:project-file");
+      expect(screen.getByLabelText("toast")).toHaveTextContent(
+        "Project exported.",
+      );
+      expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
+      expect(blobParts).toHaveLength(1);
+
+      const [serializedProject] = blobParts[0];
+      expect(JSON.parse(serializedProject as string)).toEqual({
+        version: 1,
+        nodes: editedNodes,
+        connections: editedConnections,
+      });
+    } finally {
+      if (createObjectURLDescriptor) {
+        Object.defineProperty(
+          URL,
+          "createObjectURL",
+          createObjectURLDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(URL, "createObjectURL");
+      }
+
+      if (revokeObjectURLDescriptor) {
+        Object.defineProperty(
+          URL,
+          "revokeObjectURL",
+          revokeObjectURLDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(URL, "revokeObjectURL");
+      }
+    }
+  });
+```
+
+- [ ] **Step 3: Add import success, import failure, reset, and toast timeout tests**
+
+Append these tests inside the same `describe` block after the export test, then close the `describe` block with the final `});` shown below:
+
+```tsx
+it("imports a valid project, closes the menu, clears editor workflow state, and clears the input", async () => {
+  render(<WorkflowHarness />);
+
+  const fileInput = screen.getByLabelText<HTMLInputElement>(
+    /import project file/i,
+  );
+  const projectFile = new File([createProjectContent()], "project.json", {
+    type: "application/json",
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+  fireEvent.change(fileInput, { target: { files: [projectFile] } });
+
+  await waitFor(() =>
+    expect(screen.getByLabelText("nodes")).toHaveTextContent("dense"),
+  );
+  expect(screen.getByLabelText("connections")).toHaveTextContent(
+    "connection-tensor-dense",
+  );
+  expect(screen.getByLabelText("toast")).toHaveTextContent(
+    "Project imported.",
+  );
+  expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
+  expect(screen.getByLabelText("selected")).toHaveTextContent("none");
+  expect(screen.getByLabelText("connection source")).toHaveTextContent("none");
+  expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
+    "none",
+  );
+  expect(screen.getByLabelText("dragged")).toHaveTextContent("none");
+  expect(fileInput).toHaveValue("");
+});
+
+it("keeps the menu open and preserves editor workflow state after invalid import", async () => {
+  render(<WorkflowHarness />);
+
+  const fileInput = screen.getByLabelText<HTMLInputElement>(
+    /import project file/i,
+  );
+  const invalidFile = new File(["not-json"], "project.json", {
+    type: "application/json",
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+  fireEvent.change(fileInput, { target: { files: [invalidFile] } });
+
+  await waitFor(() =>
+    expect(screen.getByLabelText("toast")).toHaveTextContent(
+      "Project file is not valid JSON.",
+    ),
+  );
+  expect(screen.getByLabelText("menu state")).toHaveTextContent("open");
+  expect(screen.getByLabelText("nodes")).toHaveTextContent("tensor");
+  expect(screen.getByLabelText("selected")).toHaveTextContent("tensor");
+  expect(screen.getByLabelText("connection source")).toHaveTextContent(
+    "tensor",
+  );
+  expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
+    "Existing feedback",
+  );
+  expect(screen.getByLabelText("dragged")).toHaveTextContent("tensor");
+  expect(fileInput).toHaveValue("");
+});
+
+it("shows a read failure toast without closing the menu or clearing dragged state", async () => {
+  const unreadableFile = {
+    text: vi.fn().mockRejectedValue(new Error("read failed")),
+  } as unknown as File;
+
+  render(<WorkflowHarness />);
+
+  const fileInput = screen.getByLabelText<HTMLInputElement>(
+    /import project file/i,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+  fireEvent.change(fileInput, { target: { files: [unreadableFile] } });
+
+  await waitFor(() =>
+    expect(screen.getByLabelText("toast")).toHaveTextContent(
+      "Project file could not be read.",
+    ),
+  );
+  expect(screen.getByLabelText("menu state")).toHaveTextContent("open");
+  expect(screen.getByLabelText("dragged")).toHaveTextContent("tensor");
+  expect(fileInput).toHaveValue("");
+});
+
+it("resets the project, closes the menu, and clears editor workflow state", () => {
+  render(
+    <WorkflowHarness
+      initialGraphNodes={editedNodes}
+      initialGraphConnections={editedConnections}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+  fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+  expect(screen.getByLabelText("nodes")).toHaveTextContent("tensor");
+  expect(screen.getByLabelText("connections")).toHaveTextContent("");
+  expect(screen.getByLabelText("toast")).toHaveTextContent("Project reset.");
+  expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
+  expect(screen.getByLabelText("selected")).toHaveTextContent("none");
+  expect(screen.getByLabelText("connection source")).toHaveTextContent("none");
+  expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
+    "none",
+  );
+  expect(screen.getByLabelText("dragged")).toHaveTextContent("none");
+});
+
+it("clears project toasts after three seconds", () => {
+  vi.useFakeTimers();
+
+  render(<WorkflowHarness />);
+
+  fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+  expect(screen.getByLabelText("toast")).toHaveTextContent("Project reset.");
+
+  act(() => {
+    vi.advanceTimersByTime(3000);
+  });
+
+  expect(screen.getByLabelText("toast")).toHaveTextContent("none");
+
+  vi.useRealTimers();
+});
+
+});
+```
+
+- [ ] **Step 4: Run the new test file and confirm it fails for the missing hook**
+
+Run:
+
+```sh
+pnpm test -- src/useProjectFileWorkflow.test.tsx
+```
+
+Expected: FAIL because `./useProjectFileWorkflow` does not exist yet.
+
+- [ ] **Step 5: Commit failing tests**
+
+Run:
+
+```sh
+git add src/useProjectFileWorkflow.test.tsx
+git commit -m "test: cover project file workflow boundary"
+```
+
+Expected: commit succeeds with only the new test file staged.
+
+---
+
+### Task 2: Implement `useProjectFileWorkflow`
+
+**Files:**
+- Create: `src/useProjectFileWorkflow.ts`
+- Test: `src/useProjectFileWorkflow.test.tsx`
+
+- [ ] **Step 1: Create the hook implementation**
+
+Create `src/useProjectFileWorkflow.ts` with this content:
+
+```ts
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+import {
+  createProjectFile,
+  parseProjectFileContent,
+  serializeProjectFile,
+} from "./projectFile";
+import type { GraphConnection, GraphNode } from "./projectFile";
+
+type UseProjectFileWorkflowOptions = {
+  graphNodes: GraphNode[];
+  graphConnections: GraphConnection[];
+  setGraphNodes: Dispatch<SetStateAction<GraphNode[]>>;
+  setGraphConnections: Dispatch<SetStateAction<GraphConnection[]>>;
+  createInitialGraphNodes: () => GraphNode[];
+  clearSelectedNode: () => void;
+  clearConnectionSource: () => void;
+  clearConnectionFeedback: () => void;
+  clearDraggedNode: () => void;
+};
+
+export function readTextFile(file: File) {
+  if (typeof file.text === "function") {
+    return file.text();
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+
+      reject(new Error("Project file could not be read as text."));
+    });
+    reader.addEventListener("error", () => {
+      reject(new Error("Project file could not be read."));
+    });
+    reader.readAsText(file);
+  });
+}
+
+export function useProjectFileWorkflow({
+  graphNodes,
+  graphConnections,
+  setGraphNodes,
+  setGraphConnections,
+  createInitialGraphNodes,
+  clearSelectedNode,
+  clearConnectionSource,
+  clearConnectionFeedback,
+  clearDraggedNode,
+}: UseProjectFileWorkflowOptions) {
+  const [isProjectActionsOpen, setIsProjectActionsOpen] = useState(false);
+  const [projectToast, setProjectToast] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!projectToast) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => setProjectToast(null), 3000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [projectToast]);
+
+  const toggleProjectActions = useCallback(() => {
+    setIsProjectActionsOpen((isOpen) => !isOpen);
+  }, []);
+
+  const openProjectImportPicker = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const clearEditorProjectWorkflowState = useCallback(() => {
+    clearSelectedNode();
+    clearConnectionSource();
+    clearConnectionFeedback();
+    clearDraggedNode();
+  }, [
+    clearConnectionFeedback,
+    clearConnectionSource,
+    clearDraggedNode,
+    clearSelectedNode,
+  ]);
+
+  const exportProjectFile = useCallback(() => {
+    const project = createProjectFile(graphNodes, graphConnections);
+    const blob = new Blob([serializeProjectFile(project)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const downloadLink = document.createElement("a");
+
+    downloadLink.href = url;
+    downloadLink.download = "dl-graph-studio-project.json";
+    document.body.append(downloadLink);
+    downloadLink.click();
+    downloadLink.remove();
+    URL.revokeObjectURL(url);
+
+    setProjectToast("Project exported.");
+    setIsProjectActionsOpen(false);
+  }, [graphConnections, graphNodes]);
+
+  const importProjectFile = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+
+      if (!file) {
+        return;
+      }
+
+      let content: string;
+
+      try {
+        content = await readTextFile(file);
+      } catch {
+        setProjectToast("Project file could not be read.");
+        event.target.value = "";
+        return;
+      }
+
+      const result = parseProjectFileContent(content);
+
+      if (!result.ok) {
+        setProjectToast(result.message);
+        event.target.value = "";
+        return;
+      }
+
+      setGraphNodes(result.project.nodes);
+      setGraphConnections(result.project.connections);
+      clearEditorProjectWorkflowState();
+      setProjectToast("Project imported.");
+      setIsProjectActionsOpen(false);
+      event.target.value = "";
+    },
+    [
+      clearEditorProjectWorkflowState,
+      setGraphConnections,
+      setGraphNodes,
+    ],
+  );
+
+  const resetProject = useCallback(() => {
+    setGraphNodes(createInitialGraphNodes());
+    setGraphConnections([]);
+    clearEditorProjectWorkflowState();
+    setProjectToast("Project reset.");
+    setIsProjectActionsOpen(false);
+  }, [
+    clearEditorProjectWorkflowState,
+    createInitialGraphNodes,
+    setGraphConnections,
+    setGraphNodes,
+  ]);
+
+  return {
+    isProjectActionsOpen,
+    setIsProjectActionsOpen,
+    toggleProjectActions,
+    projectToast,
+    fileInputRef,
+    openProjectImportPicker,
+    exportProjectFile,
+    importProjectFile,
+    resetProject,
+  };
+}
+```
+
+- [ ] **Step 2: Run the hook tests**
+
+Run:
+
+```sh
+pnpm test -- src/useProjectFileWorkflow.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the hook implementation**
+
+Run:
+
+```sh
+git add src/useProjectFileWorkflow.ts src/useProjectFileWorkflow.test.tsx
+git commit -m "feat: extract project file workflow hook"
+```
+
+Expected: commit succeeds with hook and adjusted tests.
+
+---
+
+### Task 3: Wire `App.tsx` To The Hook
+
+**Files:**
+- Modify: `src/App.tsx`
+- Test: `src/App.test.tsx`
+- Test: `src/App.nodeDrag.test.tsx`
+
+- [ ] **Step 1: Update imports in `src/App.tsx`**
+
+Remove `useEffect`, `useRef`, and `ChangeEvent` from React imports if they are no longer used by `App.tsx`. Add:
+
+```ts
+import { useProjectFileWorkflow } from "./useProjectFileWorkflow";
+```
+
+Keep `KeyboardEvent` imported because node cards still use it.
+
+- [ ] **Step 2: Remove project workflow imports from `src/App.tsx`**
+
+Remove these imports from the `./projectFile` value import list:
+
+```ts
+createProjectFile,
+parseProjectFileContent,
+serializeProjectFile,
+```
+
+Keep:
+
+```ts
+updateGraphNodePositions,
+```
+
+- [ ] **Step 3: Delete the local `readTextFile` helper from `src/App.tsx`**
+
+Remove the whole function that starts with:
+
+```ts
+function readTextFile(file: File) {
+```
+
+and ends after:
+
+```ts
+    reader.readAsText(file);
+  });
+}
+```
+
+- [ ] **Step 4: Replace local project workflow state with the hook call**
+
+Delete these local state/ref declarations from `App`:
+
+```ts
+const [isProjectActionsOpen, setIsProjectActionsOpen] = useState(false);
+const [projectToast, setProjectToast] = useState<string | null>(null);
+const fileInputRef = useRef<HTMLInputElement | null>(null);
+```
+
+Add this hook call after `canvasNodeExtent` state is declared:
+
+```ts
+const {
+  isProjectActionsOpen,
+  setIsProjectActionsOpen,
+  projectToast,
+  fileInputRef,
+  openProjectImportPicker,
+  exportProjectFile,
+  importProjectFile,
+  resetProject,
+} = useProjectFileWorkflow({
+  graphNodes,
+  graphConnections,
+  setGraphNodes,
+  setGraphConnections,
+  createInitialGraphNodes,
+  clearSelectedNode: () => setSelectedNodeId(null),
+  clearConnectionSource: () => setConnectionSourceId(null),
+  clearConnectionFeedback: () => setConnectionFeedback(null),
+  clearDraggedNode: () => setDraggedNodeId(null),
+});
+```
+
+- [ ] **Step 5: Delete toast timeout effect and local project handlers**
+
+Remove the `useEffect` that auto-clears `projectToast`; the hook owns it now.
+
+Remove these local functions from `App`:
+
+```ts
+const exportProjectFile = () => { ... };
+const importProjectFile = async (event: ChangeEvent<HTMLInputElement>) => { ... };
+const resetProject = () => { ... };
+```
+
+- [ ] **Step 6: Update import menu button wiring**
+
+Find the import menu item in the project actions menu. Replace the existing inline click handler:
+
+```tsx
+onClick={() => fileInputRef.current?.click()}
+```
+
+with:
+
+```tsx
+onClick={openProjectImportPicker}
+```
+
+Keep the hidden input props unchanged except for using the hook-provided `fileInputRef` and `importProjectFile`.
+
+- [ ] **Step 7: Run App integration tests**
+
+Run:
+
+```sh
+pnpm test -- src/App.test.tsx src/App.nodeDrag.test.tsx
+```
+
+Expected: PASS. These tests prove import, export, reset, parameter editing, connection creation, deletion, and drag behavior still work from the app surface.
+
+- [ ] **Step 8: Run TypeScript build**
+
+Run:
+
+```sh
+pnpm build
+```
+
+Expected: PASS. Fix any unused imports or hook dependency typing errors before continuing.
+
+- [ ] **Step 9: Commit App wiring**
+
+Run:
+
+```sh
+git add src/App.tsx
+git commit -m "refactor: delegate app project workflow"
+```
+
+Expected: commit succeeds with only `src/App.tsx` staged.
+
+---
+
+### Task 4: Full Verification And Cleanup
+
+**Files:**
+- Review: `src/App.tsx`
+- Review: `src/useProjectFileWorkflow.ts`
+- Review: `src/useProjectFileWorkflow.test.tsx`
+- Review: `docs/superpowers/specs/2026-05-04-extract-app-project-file-workflow-design.md`
+
+- [ ] **Step 1: Run full test suite**
+
+Run:
+
+```sh
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```sh
+pnpm lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build**
+
+Run:
+
+```sh
+pnpm build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run format check**
+
+Run:
+
+```sh
+pnpm format:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff for scope**
+
+Run:
+
+```sh
+git diff --stat origin/main...HEAD
+git diff -- src/App.tsx src/useProjectFileWorkflow.ts src/useProjectFileWorkflow.test.tsx
+```
+
+Expected:
+
+- `src/App.tsx` delegates project workflow to the hook.
+- `src/useProjectFileWorkflow.ts` owns only project workflow logic.
+- Tests cover the extracted boundary.
+- No project file format, styling, React Flow behavior, node rendering, inspector behavior, or validation rules changed.
+
+- [ ] **Step 6: Commit final test or formatting fixes when changes exist**
+
+Check for uncommitted changes:
+
+```sh
+git status --short
+```
+
+When the command shows modified files from verification fixes, run:
+
+```sh
+git add src/App.tsx src/useProjectFileWorkflow.ts src/useProjectFileWorkflow.test.tsx
+git commit -m "test: stabilize project workflow extraction"
+```
+
+Expected with modified files: commit succeeds. Expected with no output from `git status --short`: no commit is created.
+
+- [ ] **Step 7: Prepare manual verification notes**
+
+Use these notes in the final implementation summary and future PR body:
+
+```md
+Manual verification to run before PR:
+
+1. Open the app and confirm the workspace renders primitive and composite nodes.
+2. Open the project actions menu and export the current project.
+3. Import a valid project file and confirm the canvas updates.
+4. Reset the project and confirm the default graph returns.
+5. Edit a parameter and confirm the inspector/node card update.
+6. Create a connection and confirm it renders.
+```
+
+Expected: notes match issue #35 manual verification and mention no new behavior except the dragged-state cleanup bug fix.

--- a/docs/superpowers/specs/2026-05-04-extract-app-project-file-workflow-design.md
+++ b/docs/superpowers/specs/2026-05-04-extract-app-project-file-workflow-design.md
@@ -1,0 +1,200 @@
+# Extract App Project File Workflow Design
+
+## Context
+
+Issue #35 follows the Phase 1 technical audit finding that `src/App.tsx`
+owns too many responsibilities at once. The current component manages graph
+state, React Flow adapter state, inspector behavior, connection validation,
+node dragging, layout rendering, and the project file workflow.
+
+The project file format and validation already live in `src/projectFile.ts`.
+That module defines the persisted graph types and owns project cloning,
+serialization, parsing, validation, and node position updates. The next
+maintenance step is to move the browser import/export/reset workflow out of
+`App.tsx` without changing the visible editor behavior or the persisted file
+shape.
+
+## Goal
+
+Extract the project file workflow from `src/App.tsx` into a focused,
+maintainable boundary that can grow with future project actions while keeping
+this pull request limited to the current browser-based behavior.
+
+The extraction should make `App.tsx` delegate project import, export, reset,
+menu state, toast state, file input ownership, and file reading orchestration
+through a clear interface. `App.tsx` should remain responsible for rendering the
+editor shell, canvas, inspector, React Flow mapping, graph interaction, and
+styling.
+
+## Non-Goals
+
+- Do not change the project file format.
+- Do not add Tauri native file dialogs, native filesystem access, autosave, or
+  additional persistence capabilities.
+- Do not change graph editing behavior, React Flow integration, node rendering,
+  inspector behavior, validation rules, or styling.
+- Do not broadly decompose `App.tsx` beyond the project file workflow.
+- Do not add dependencies.
+
+## Recommended Approach
+
+Create a focused hook, `useProjectFileWorkflow`, in
+`src/useProjectFileWorkflow.ts`.
+
+The hook should be the local API for current project actions. It should hide
+browser file IO details and project workflow side effects from `App.tsx`, while
+accepting the graph state and editor cleanup callbacks it needs from the app.
+
+This boundary is intentionally more durable than a set of one-off helpers. A
+future roadmap issue can change the hook internals to use Tauri-native file
+dialogs or add more project actions without spreading file workflow details
+back into `App.tsx`. This issue should not implement those future capabilities.
+
+## Hook Interface
+
+`useProjectFileWorkflow` should receive:
+
+- `graphNodes`
+- `graphConnections`
+- `setGraphNodes`
+- `setGraphConnections`
+- `createInitialGraphNodes`
+- cleanup callbacks for selected node, connection source, connection feedback,
+  and dragged node state
+
+It should return:
+
+- `isProjectActionsOpen`
+- a way to toggle or set the project actions menu state
+- `projectToast`
+- `fileInputRef`
+- `openProjectImportPicker`
+- `exportProjectFile`
+- `importProjectFile`
+- `resetProject`
+
+The exact TypeScript names can follow the implementation if they stay clear and
+small. The important contract is that `App.tsx` renders controls and passes
+events through the hook instead of owning project workflow logic directly.
+
+## Data Flow
+
+`App.tsx` remains the owner of the canonical editor state:
+
+- graph nodes
+- graph connections
+- selected node id
+- dragged node id
+- connection source id
+- connection feedback
+- canvas extent
+- React Flow nodes and edges
+- inspector rendering and parameter editing
+
+`useProjectFileWorkflow` receives the current project state for export and
+receives setter or cleanup callbacks for import and reset.
+
+Export flow:
+
+1. Build a project with `createProjectFile(graphNodes, graphConnections)`.
+2. Serialize with `serializeProjectFile`.
+3. Create a JSON `Blob`.
+4. Create an object URL.
+5. Click a temporary download anchor using the existing filename
+   `dl-graph-studio-project.json`.
+6. Remove the anchor and revoke the object URL.
+7. Show `Project exported.`.
+8. Close the project actions menu.
+
+Import flow:
+
+1. Read the first selected file.
+2. If no file is selected, do nothing.
+3. If reading fails, show `Project file could not be read.`, clear the file
+   input, keep the menu state unchanged, and leave graph/editor state
+   unchanged.
+4. Parse with `parseProjectFileContent`.
+5. If parsing fails, show the parser message, clear the file input, keep the
+   menu state unchanged, and leave graph/editor state unchanged.
+6. On success, replace nodes and connections with the imported project.
+7. Clear selected node, connection source, connection feedback, and dragged
+   node state.
+8. Show `Project imported.`.
+9. Close the project actions menu.
+10. Clear the file input.
+
+Reset flow:
+
+1. Replace nodes with `createInitialGraphNodes()`.
+2. Clear connections.
+3. Clear selected node, connection source, connection feedback, and dragged
+   node state.
+4. Show `Project reset.`.
+5. Close the project actions menu.
+
+`src/projectFile.ts` should remain the project format boundary. It should not
+start owning browser file input, toasts, menu state, or DOM download effects.
+
+## Drag State Cleanup
+
+The current implementation does not clear `draggedNodeId` during import or
+reset. This is a small state consistency bug within the project workflow
+boundary: after replacing or resetting the project, an old dragged node id no
+longer describes the active graph interaction.
+
+This issue should fix that bug only for successful import and reset by passing
+a focused dragged-state cleanup callback into the hook. Failed imports should
+not clear dragged state, because they do not change the active project.
+
+## Error Handling
+
+The extraction should preserve current user-facing messages and menu behavior:
+
+- Import without a file does nothing.
+- File read failure shows `Project file could not be read.`.
+- Invalid project files show the exact message returned by
+  `parseProjectFileContent`.
+- Failed imports clear the file input but do not close the project actions
+  menu.
+- Successful imports clear the file input and close the menu.
+- Export and reset close the menu.
+- Project toasts auto-clear after 3000 milliseconds.
+
+## Testing
+
+Keep existing `App.test.tsx`, `App.nodeDrag.test.tsx`, and
+`projectFile.test.ts` coverage passing.
+
+Add focused coverage for the extracted boundary where practical. A small test
+harness around `useProjectFileWorkflow` is preferred if it keeps assertions
+direct and avoids over-coupling to unrelated `App.tsx` rendering.
+
+Coverage should include:
+
+- export still serializes current nodes and connections and performs the same
+  browser download side effects;
+- valid import replaces project state, closes the menu, clears the input, and
+  clears selected node, connection source, connection feedback, and dragged
+  node state;
+- invalid import or read failure shows the correct toast, clears the input, and
+  does not close the menu or clear dragged state;
+- reset restores initial nodes, clears connections, closes the menu, and clears
+  selected node, connection source, connection feedback, and dragged node state;
+- existing integration tests still confirm import, export, reset, parameter
+  editing, connection, and drag behavior remain stable.
+
+The issue verification remains:
+
+```sh
+pnpm test
+pnpm lint
+pnpm build
+pnpm format:check
+```
+
+## Review Boundaries
+
+The pull request should stay reviewable in the normal 15-30 minute window. If
+implementation reveals additional `App.tsx` responsibilities that should be
+extracted, they should become follow-up roadmap issues unless they are directly
+needed for this project file workflow boundary.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,13 +23,7 @@ import {
   Download,
   Upload,
 } from "lucide-react";
-import {
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, KeyboardEvent } from "react";
 import {
   Background,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,6 @@ import {
 } from "lucide-react";
 import {
   useCallback,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -50,12 +49,7 @@ import type {
 } from "@xyflow/react";
 
 import "@xyflow/react/dist/style.css";
-import {
-  createProjectFile,
-  parseProjectFileContent,
-  serializeProjectFile,
-  updateGraphNodePositions,
-} from "./projectFile";
+import { updateGraphNodePositions } from "./projectFile";
 import type {
   CompositeNode,
   GraphNode,
@@ -64,6 +58,7 @@ import type {
   PrimitiveNode,
   PrimitiveNodeParameter,
 } from "./projectFile";
+import { useProjectFileWorkflow } from "./useProjectFileWorkflow";
 
 type ConnectionValidationResult =
   | { isValid: true }
@@ -307,29 +302,6 @@ function getCanvasElementNodeExtent(
   }
 
   return getCanvasNodeExtent({ width, height });
-}
-
-function readTextFile(file: File) {
-  if (typeof file.text === "function") {
-    return file.text();
-  }
-
-  return new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-
-    reader.addEventListener("load", () => {
-      if (typeof reader.result === "string") {
-        resolve(reader.result);
-        return;
-      }
-
-      reject(new Error("Project file could not be read as text."));
-    });
-    reader.addEventListener("error", () => {
-      reject(new Error("Project file could not be read."));
-    });
-    reader.readAsText(file);
-  });
 }
 
 function areCanvasNodeExtentsEqual(
@@ -579,16 +551,33 @@ export function App() {
   const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
     null,
   );
-  const [isProjectActionsOpen, setIsProjectActionsOpen] = useState(false);
-  const [projectToast, setProjectToast] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const graphCanvasRef = useRef<HTMLElement | null>(null);
+  const [canvasNodeExtent, setCanvasNodeExtent] =
+    useState<CoordinateExtent | null>(null);
+  const {
+    isProjectActionsOpen,
+    setIsProjectActionsOpen,
+    projectToast,
+    fileInputRef,
+    openProjectImportPicker,
+    exportProjectFile,
+    importProjectFile,
+    resetProject,
+  } = useProjectFileWorkflow({
+    graphNodes,
+    graphConnections,
+    setGraphNodes,
+    setGraphConnections,
+    createInitialGraphNodes,
+    clearSelectedNode: () => setSelectedNodeId(null),
+    clearConnectionSource: () => setConnectionSourceId(null),
+    clearConnectionFeedback: () => setConnectionFeedback(null),
+    clearDraggedNode: () => setDraggedNodeId(null),
+  });
   const selectedNode =
     graphNodes.find((node) => node.id === selectedNodeId) ?? null;
   const connectionSource =
     graphNodes.find((node) => node.id === connectionSourceId) ?? null;
-  const graphCanvasRef = useRef<HTMLElement | null>(null);
-  const [canvasNodeExtent, setCanvasNodeExtent] =
-    useState<CoordinateExtent | null>(null);
 
   useLayoutEffect(() => {
     const graphCanvasElement = graphCanvasRef.current;
@@ -633,16 +622,6 @@ export function App() {
       clampGraphNodesToCanvas(currentNodes, canvasNodeExtent),
     );
   }, [canvasNodeExtent, graphNodes]);
-
-  useEffect(() => {
-    if (!projectToast) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => setProjectToast(null), 3000);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [projectToast]);
 
   const updateNodeParameter = (
     nodeId: string,
@@ -794,70 +773,6 @@ export function App() {
     },
     [graphConnections, graphNodes],
   );
-
-  const exportProjectFile = () => {
-    const project = createProjectFile(graphNodes, graphConnections);
-    const blob = new Blob([serializeProjectFile(project)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const downloadLink = document.createElement("a");
-
-    downloadLink.href = url;
-    downloadLink.download = "dl-graph-studio-project.json";
-    document.body.append(downloadLink);
-    downloadLink.click();
-    downloadLink.remove();
-    URL.revokeObjectURL(url);
-
-    setProjectToast("Project exported.");
-    setIsProjectActionsOpen(false);
-  };
-
-  const importProjectFile = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-
-    if (!file) {
-      return;
-    }
-
-    let content: string;
-
-    try {
-      content = await readTextFile(file);
-    } catch {
-      setProjectToast("Project file could not be read.");
-      event.target.value = "";
-      return;
-    }
-
-    const result = parseProjectFileContent(content);
-
-    if (!result.ok) {
-      setProjectToast(result.message);
-      event.target.value = "";
-      return;
-    }
-
-    setGraphNodes(result.project.nodes);
-    setGraphConnections(result.project.connections);
-    setSelectedNodeId(null);
-    setConnectionSourceId(null);
-    setConnectionFeedback(null);
-    setProjectToast("Project imported.");
-    setIsProjectActionsOpen(false);
-    event.target.value = "";
-  };
-
-  const resetProject = () => {
-    setGraphNodes(createInitialGraphNodes());
-    setGraphConnections([]);
-    setSelectedNodeId(null);
-    setConnectionSourceId(null);
-    setConnectionFeedback(null);
-    setProjectToast("Project reset.");
-    setIsProjectActionsOpen(false);
-  };
 
   const canvasNodes: GraphFlowNode[] = useMemo(
     () =>
@@ -1068,7 +983,7 @@ export function App() {
                 <button
                   type="button"
                   role="menuitem"
-                  onClick={() => fileInputRef.current?.click()}
+                  onClick={openProjectImportPicker}
                 >
                   <Upload size={15} aria-hidden="true" />
                   <span>Import project</span>

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -116,7 +116,9 @@ function WorkflowHarness({
         {graphNodes.map((node) => node.id).join(",")}
       </output>
       <output aria-label="connections">
-        {graphConnections.map((connection) => connection.id).join(",")}
+        {graphConnections.length === 0
+          ? "none"
+          : graphConnections.map((connection) => connection.id).join(",")}
       </output>
       <output aria-label="selected">{selectedNodeId ?? "none"}</output>
       <output aria-label="connection source">
@@ -144,6 +146,8 @@ describe("useProjectFileWorkflow", () => {
     );
     const createObjectURL = vi.fn(() => "blob:project-file");
     const revokeObjectURL = vi.fn();
+    const createdAnchors: HTMLAnchorElement[] = [];
+    const originalCreateElement = document.createElement.bind(document);
 
     vi.stubGlobal(
       "Blob",
@@ -162,8 +166,19 @@ describe("useProjectFileWorkflow", () => {
     });
 
     try {
-      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
-        () => undefined,
+      const anchorClick = vi
+        .spyOn(HTMLAnchorElement.prototype, "click")
+        .mockImplementation(() => undefined);
+      vi.spyOn(document, "createElement").mockImplementation(
+        ((tagName: string, options?: ElementCreationOptions) => {
+          const element = originalCreateElement(tagName, options);
+
+          if (tagName.toLowerCase() === "a") {
+            createdAnchors.push(element as HTMLAnchorElement);
+          }
+
+          return element;
+        }) as typeof document.createElement,
       );
 
       render(
@@ -178,10 +193,16 @@ describe("useProjectFileWorkflow", () => {
 
       expect(createObjectURL).toHaveBeenCalledTimes(1);
       expect(revokeObjectURL).toHaveBeenCalledWith("blob:project-file");
+      expect(anchorClick).toHaveBeenCalledTimes(1);
+      expect(createdAnchors).toHaveLength(1);
+      expect(createdAnchors[0]).toHaveAttribute(
+        "download",
+        "dl-graph-studio-project.json",
+      );
       expect(screen.getByLabelText("toast")).toHaveTextContent(
         "Project exported.",
       );
-      expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
+      expect(screen.getByLabelText("menu state")).toHaveTextContent(/^closed$/);
       expect(blobParts).toHaveLength(1);
 
       const [serializedProject] = blobParts[0];
@@ -227,23 +248,25 @@ describe("useProjectFileWorkflow", () => {
     fireEvent.change(fileInput, { target: { files: [projectFile] } });
 
     await waitFor(() =>
-      expect(screen.getByLabelText("nodes")).toHaveTextContent("dense"),
+      expect(screen.getByLabelText("nodes")).toHaveTextContent(
+        /^tensor,dense$/,
+      ),
     );
     expect(screen.getByLabelText("connections")).toHaveTextContent(
-      "connection-tensor-dense",
+      /^connection-tensor-dense$/,
     );
     expect(screen.getByLabelText("toast")).toHaveTextContent(
       "Project imported.",
     );
-    expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
-    expect(screen.getByLabelText("selected")).toHaveTextContent("none");
+    expect(screen.getByLabelText("menu state")).toHaveTextContent(/^closed$/);
+    expect(screen.getByLabelText("selected")).toHaveTextContent(/^none$/);
     expect(screen.getByLabelText("connection source")).toHaveTextContent(
-      "none",
+      /^none$/,
     );
     expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
-      "none",
+      /^none$/,
     );
-    expect(screen.getByLabelText("dragged")).toHaveTextContent("none");
+    expect(screen.getByLabelText("dragged")).toHaveTextContent(/^none$/);
     expect(fileInput).toHaveValue("");
   });
 
@@ -265,16 +288,17 @@ describe("useProjectFileWorkflow", () => {
         "Project file is not valid JSON.",
       ),
     );
-    expect(screen.getByLabelText("menu state")).toHaveTextContent("open");
-    expect(screen.getByLabelText("nodes")).toHaveTextContent("tensor");
-    expect(screen.getByLabelText("selected")).toHaveTextContent("tensor");
+    expect(screen.getByLabelText("menu state")).toHaveTextContent(/^open$/);
+    expect(screen.getByLabelText("nodes")).toHaveTextContent(/^tensor$/);
+    expect(screen.getByLabelText("connections")).toHaveTextContent(/^none$/);
+    expect(screen.getByLabelText("selected")).toHaveTextContent(/^tensor$/);
     expect(screen.getByLabelText("connection source")).toHaveTextContent(
-      "tensor",
+      /^tensor$/,
     );
     expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
-      "Existing feedback",
+      /^Existing feedback$/,
     );
-    expect(screen.getByLabelText("dragged")).toHaveTextContent("tensor");
+    expect(screen.getByLabelText("dragged")).toHaveTextContent(/^tensor$/);
     expect(fileInput).toHaveValue("");
   });
 
@@ -297,8 +321,8 @@ describe("useProjectFileWorkflow", () => {
         "Project file could not be read.",
       ),
     );
-    expect(screen.getByLabelText("menu state")).toHaveTextContent("open");
-    expect(screen.getByLabelText("dragged")).toHaveTextContent("tensor");
+    expect(screen.getByLabelText("menu state")).toHaveTextContent(/^open$/);
+    expect(screen.getByLabelText("dragged")).toHaveTextContent(/^tensor$/);
     expect(fileInput).toHaveValue("");
   });
 
@@ -313,18 +337,18 @@ describe("useProjectFileWorkflow", () => {
     fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
     fireEvent.click(screen.getByRole("button", { name: /reset/i }));
 
-    expect(screen.getByLabelText("nodes")).toHaveTextContent("tensor");
-    expect(screen.getByLabelText("connections")).toHaveTextContent("");
+    expect(screen.getByLabelText("nodes")).toHaveTextContent(/^tensor$/);
+    expect(screen.getByLabelText("connections")).toHaveTextContent(/^none$/);
     expect(screen.getByLabelText("toast")).toHaveTextContent("Project reset.");
-    expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
-    expect(screen.getByLabelText("selected")).toHaveTextContent("none");
+    expect(screen.getByLabelText("menu state")).toHaveTextContent(/^closed$/);
+    expect(screen.getByLabelText("selected")).toHaveTextContent(/^none$/);
     expect(screen.getByLabelText("connection source")).toHaveTextContent(
-      "none",
+      /^none$/,
     );
     expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
-      "none",
+      /^none$/,
     );
-    expect(screen.getByLabelText("dragged")).toHaveTextContent("none");
+    expect(screen.getByLabelText("dragged")).toHaveTextContent(/^none$/);
   });
 
   it("clears project toasts after three seconds", () => {
@@ -340,7 +364,7 @@ describe("useProjectFileWorkflow", () => {
       vi.advanceTimersByTime(3000);
     });
 
-    expect(screen.getByLabelText("toast")).toHaveTextContent("none");
+    expect(screen.getByLabelText("toast")).toHaveTextContent(/^none$/);
 
     vi.useRealTimers();
   });

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
-import { useProjectFileWorkflow } from "./useProjectFileWorkflow";
+import { readTextFile, useProjectFileWorkflow } from "./useProjectFileWorkflow";
 import type { GraphConnection, GraphNode } from "./projectFile";
 
 afterEach(() => {
@@ -133,6 +133,16 @@ function WorkflowHarness({
 }
 
 describe("useProjectFileWorkflow", () => {
+  it("rejects file.text results that are not strings", async () => {
+    const nonTextFile = {
+      text: vi.fn().mockResolvedValue(42),
+    } as unknown as File;
+
+    await expect(readTextFile(nonTextFile)).rejects.toThrow(
+      "Project file could not be read as text.",
+    );
+  });
+
   it("exports the current project and closes the project actions menu", () => {
     const OriginalBlob = globalThis.Blob;
     const blobParts: BlobPart[][] = [];

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -44,7 +44,7 @@ const editedConnections: GraphConnection[] = [
 ];
 
 function createProjectContent(
-  nodes: GraphNode[] = editedNodes,
+  nodes: GraphNode[] = [...initialNodes, ...editedNodes],
   connections: GraphConnection[] = editedConnections,
 ) {
   return JSON.stringify({

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -1,0 +1,345 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { useProjectFileWorkflow } from "./useProjectFileWorkflow";
+import type { GraphConnection, GraphNode } from "./projectFile";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+const initialNodes: GraphNode[] = [
+  {
+    id: "tensor",
+    type: "primitive",
+    label: "Tensor",
+    kind: "Data",
+    metadata: ["Role: data carrier"],
+    parameters: [
+      { id: "shape", label: "Shape", type: "text", value: "dynamic" },
+    ],
+    position: { x: 96, y: 64 },
+  },
+];
+
+const editedNodes: GraphNode[] = [
+  {
+    id: "dense",
+    type: "primitive",
+    label: "Dense",
+    kind: "Layer",
+    metadata: ["Role: transform"],
+    parameters: [
+      { id: "units", label: "Units", type: "number", value: 128 },
+    ],
+    position: { x: 320, y: 96 },
+  },
+];
+
+const editedConnections: GraphConnection[] = [
+  { id: "connection-tensor-dense", source: "tensor", target: "dense" },
+];
+
+function createProjectContent(
+  nodes: GraphNode[] = editedNodes,
+  connections: GraphConnection[] = editedConnections,
+) {
+  return JSON.stringify({
+    version: 1,
+    nodes,
+    connections,
+  });
+}
+
+function WorkflowHarness({
+  initialGraphNodes = initialNodes,
+  initialGraphConnections = [],
+}: {
+  initialGraphNodes?: GraphNode[];
+  initialGraphConnections?: GraphConnection[];
+}) {
+  const [graphNodes, setGraphNodes] = useState(initialGraphNodes);
+  const [graphConnections, setGraphConnections] = useState(
+    initialGraphConnections,
+  );
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>("tensor");
+  const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
+    "tensor",
+  );
+  const [connectionFeedback, setConnectionFeedback] = useState<string | null>(
+    "Existing feedback",
+  );
+  const [draggedNodeId, setDraggedNodeId] = useState<string | null>("tensor");
+  const workflow = useProjectFileWorkflow({
+    graphNodes,
+    graphConnections,
+    setGraphNodes,
+    setGraphConnections,
+    createInitialGraphNodes: () =>
+      initialNodes.map((node) => ({ ...node, position: { ...node.position } })),
+    clearSelectedNode: () => setSelectedNodeId(null),
+    clearConnectionSource: () => setConnectionSourceId(null),
+    clearConnectionFeedback: () => setConnectionFeedback(null),
+    clearDraggedNode: () => setDraggedNodeId(null),
+  });
+
+  return (
+    <div>
+      <button type="button" onClick={workflow.toggleProjectActions}>
+        Toggle menu
+      </button>
+      <button type="button" onClick={workflow.openProjectImportPicker}>
+        Open import
+      </button>
+      <button type="button" onClick={workflow.exportProjectFile}>
+        Export
+      </button>
+      <button type="button" onClick={workflow.resetProject}>
+        Reset
+      </button>
+      <input
+        aria-label="Import project file"
+        ref={workflow.fileInputRef}
+        type="file"
+        onChange={workflow.importProjectFile}
+      />
+      <output aria-label="menu state">
+        {workflow.isProjectActionsOpen ? "open" : "closed"}
+      </output>
+      <output aria-label="toast">{workflow.projectToast ?? "none"}</output>
+      <output aria-label="nodes">
+        {graphNodes.map((node) => node.id).join(",")}
+      </output>
+      <output aria-label="connections">
+        {graphConnections.map((connection) => connection.id).join(",")}
+      </output>
+      <output aria-label="selected">{selectedNodeId ?? "none"}</output>
+      <output aria-label="connection source">
+        {connectionSourceId ?? "none"}
+      </output>
+      <output aria-label="connection feedback">
+        {connectionFeedback ?? "none"}
+      </output>
+      <output aria-label="dragged">{draggedNodeId ?? "none"}</output>
+    </div>
+  );
+}
+
+describe("useProjectFileWorkflow", () => {
+  it("exports the current project and closes the project actions menu", () => {
+    const OriginalBlob = globalThis.Blob;
+    const blobParts: BlobPart[][] = [];
+    const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(
+      URL,
+      "createObjectURL",
+    );
+    const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(
+      URL,
+      "revokeObjectURL",
+    );
+    const createObjectURL = vi.fn(() => "blob:project-file");
+    const revokeObjectURL = vi.fn();
+
+    vi.stubGlobal(
+      "Blob",
+      vi.fn((parts?: BlobPart[], options?: BlobPropertyBag) => {
+        blobParts.push(parts ?? []);
+        return new OriginalBlob(parts, options);
+      }),
+    );
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    try {
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+        () => undefined,
+      );
+
+      render(
+        <WorkflowHarness
+          initialGraphNodes={editedNodes}
+          initialGraphConnections={editedConnections}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+      fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:project-file");
+      expect(screen.getByLabelText("toast")).toHaveTextContent(
+        "Project exported.",
+      );
+      expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
+      expect(blobParts).toHaveLength(1);
+
+      const [serializedProject] = blobParts[0];
+      expect(JSON.parse(serializedProject as string)).toEqual({
+        version: 1,
+        nodes: editedNodes,
+        connections: editedConnections,
+      });
+    } finally {
+      if (createObjectURLDescriptor) {
+        Object.defineProperty(
+          URL,
+          "createObjectURL",
+          createObjectURLDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(URL, "createObjectURL");
+      }
+
+      if (revokeObjectURLDescriptor) {
+        Object.defineProperty(
+          URL,
+          "revokeObjectURL",
+          revokeObjectURLDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(URL, "revokeObjectURL");
+      }
+    }
+  });
+
+  it("imports a valid project, closes the menu, clears editor workflow state, and clears the input", async () => {
+    render(<WorkflowHarness />);
+
+    const fileInput = screen.getByLabelText<HTMLInputElement>(
+      /import project file/i,
+    );
+    const projectFile = new File([createProjectContent()], "project.json", {
+      type: "application/json",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+    fireEvent.change(fileInput, { target: { files: [projectFile] } });
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("nodes")).toHaveTextContent("dense"),
+    );
+    expect(screen.getByLabelText("connections")).toHaveTextContent(
+      "connection-tensor-dense",
+    );
+    expect(screen.getByLabelText("toast")).toHaveTextContent(
+      "Project imported.",
+    );
+    expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
+    expect(screen.getByLabelText("selected")).toHaveTextContent("none");
+    expect(screen.getByLabelText("connection source")).toHaveTextContent(
+      "none",
+    );
+    expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
+      "none",
+    );
+    expect(screen.getByLabelText("dragged")).toHaveTextContent("none");
+    expect(fileInput).toHaveValue("");
+  });
+
+  it("keeps the menu open and preserves editor workflow state after invalid import", async () => {
+    render(<WorkflowHarness />);
+
+    const fileInput = screen.getByLabelText<HTMLInputElement>(
+      /import project file/i,
+    );
+    const invalidFile = new File(["not-json"], "project.json", {
+      type: "application/json",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+    fireEvent.change(fileInput, { target: { files: [invalidFile] } });
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("toast")).toHaveTextContent(
+        "Project file is not valid JSON.",
+      ),
+    );
+    expect(screen.getByLabelText("menu state")).toHaveTextContent("open");
+    expect(screen.getByLabelText("nodes")).toHaveTextContent("tensor");
+    expect(screen.getByLabelText("selected")).toHaveTextContent("tensor");
+    expect(screen.getByLabelText("connection source")).toHaveTextContent(
+      "tensor",
+    );
+    expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
+      "Existing feedback",
+    );
+    expect(screen.getByLabelText("dragged")).toHaveTextContent("tensor");
+    expect(fileInput).toHaveValue("");
+  });
+
+  it("shows a read failure toast without closing the menu or clearing dragged state", async () => {
+    const unreadableFile = {
+      text: vi.fn().mockRejectedValue(new Error("read failed")),
+    } as unknown as File;
+
+    render(<WorkflowHarness />);
+
+    const fileInput = screen.getByLabelText<HTMLInputElement>(
+      /import project file/i,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+    fireEvent.change(fileInput, { target: { files: [unreadableFile] } });
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("toast")).toHaveTextContent(
+        "Project file could not be read.",
+      ),
+    );
+    expect(screen.getByLabelText("menu state")).toHaveTextContent("open");
+    expect(screen.getByLabelText("dragged")).toHaveTextContent("tensor");
+    expect(fileInput).toHaveValue("");
+  });
+
+  it("resets the project, closes the menu, and clears editor workflow state", () => {
+    render(
+      <WorkflowHarness
+        initialGraphNodes={editedNodes}
+        initialGraphConnections={editedConnections}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
+    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+    expect(screen.getByLabelText("nodes")).toHaveTextContent("tensor");
+    expect(screen.getByLabelText("connections")).toHaveTextContent("");
+    expect(screen.getByLabelText("toast")).toHaveTextContent("Project reset.");
+    expect(screen.getByLabelText("menu state")).toHaveTextContent("closed");
+    expect(screen.getByLabelText("selected")).toHaveTextContent("none");
+    expect(screen.getByLabelText("connection source")).toHaveTextContent(
+      "none",
+    );
+    expect(screen.getByLabelText("connection feedback")).toHaveTextContent(
+      "none",
+    );
+    expect(screen.getByLabelText("dragged")).toHaveTextContent("none");
+  });
+
+  it("clears project toasts after three seconds", () => {
+    vi.useFakeTimers();
+
+    render(<WorkflowHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+    expect(screen.getByLabelText("toast")).toHaveTextContent("Project reset.");
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByLabelText("toast")).toHaveTextContent("none");
+
+    vi.useRealTimers();
+  });
+});

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
@@ -32,9 +38,7 @@ const editedNodes: GraphNode[] = [
     label: "Dense",
     kind: "Layer",
     metadata: ["Role: transform"],
-    parameters: [
-      { id: "units", label: "Units", type: "number", value: 128 },
-    ],
+    parameters: [{ id: "units", label: "Units", type: "number", value: 128 }],
     position: { x: 320, y: 96 },
   },
 ];
@@ -179,17 +183,18 @@ describe("useProjectFileWorkflow", () => {
       const anchorClick = vi
         .spyOn(HTMLAnchorElement.prototype, "click")
         .mockImplementation(() => undefined);
-      vi.spyOn(document, "createElement").mockImplementation(
-        ((tagName: string, options?: ElementCreationOptions) => {
-          const element = originalCreateElement(tagName, options);
+      vi.spyOn(document, "createElement").mockImplementation(((
+        tagName: string,
+        options?: ElementCreationOptions,
+      ) => {
+        const element = originalCreateElement(tagName, options);
 
-          if (tagName.toLowerCase() === "a") {
-            createdAnchors.push(element as HTMLAnchorElement);
-          }
+        if (tagName.toLowerCase() === "a") {
+          createdAnchors.push(element as HTMLAnchorElement);
+        }
 
-          return element;
-        }) as typeof document.createElement,
-      );
+        return element;
+      }) as typeof document.createElement);
 
       render(
         <WorkflowHarness
@@ -247,9 +252,8 @@ describe("useProjectFileWorkflow", () => {
   it("imports a valid project, closes the menu, clears editor workflow state, and clears the input", async () => {
     render(<WorkflowHarness />);
 
-    const fileInput = screen.getByLabelText<HTMLInputElement>(
-      /import project file/i,
-    );
+    const fileInput =
+      screen.getByLabelText<HTMLInputElement>(/import project file/i);
     const projectFile = new File([createProjectContent()], "project.json", {
       type: "application/json",
     });
@@ -283,9 +287,8 @@ describe("useProjectFileWorkflow", () => {
   it("keeps the menu open and preserves editor workflow state after invalid import", async () => {
     render(<WorkflowHarness />);
 
-    const fileInput = screen.getByLabelText<HTMLInputElement>(
-      /import project file/i,
-    );
+    const fileInput =
+      screen.getByLabelText<HTMLInputElement>(/import project file/i);
     const invalidFile = new File(["not-json"], "project.json", {
       type: "application/json",
     });
@@ -319,9 +322,8 @@ describe("useProjectFileWorkflow", () => {
 
     render(<WorkflowHarness />);
 
-    const fileInput = screen.getByLabelText<HTMLInputElement>(
-      /import project file/i,
-    );
+    const fileInput =
+      screen.getByLabelText<HTMLInputElement>(/import project file/i);
 
     fireEvent.click(screen.getByRole("button", { name: /toggle menu/i }));
     fireEvent.change(fileInput, { target: { files: [unreadableFile] } });

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -43,8 +43,10 @@ const editedConnections: GraphConnection[] = [
   { id: "connection-tensor-dense", source: "tensor", target: "dense" },
 ];
 
+const editedProjectNodes: GraphNode[] = [initialNodes[0], editedNodes[0]];
+
 function createProjectContent(
-  nodes: GraphNode[] = [...initialNodes, ...editedNodes],
+  nodes: GraphNode[] = editedProjectNodes,
   connections: GraphConnection[] = editedConnections,
 ) {
   return JSON.stringify({
@@ -166,7 +168,7 @@ describe("useProjectFileWorkflow", () => {
 
       render(
         <WorkflowHarness
-          initialGraphNodes={editedNodes}
+          initialGraphNodes={editedProjectNodes}
           initialGraphConnections={editedConnections}
         />,
       );
@@ -185,7 +187,7 @@ describe("useProjectFileWorkflow", () => {
       const [serializedProject] = blobParts[0];
       expect(JSON.parse(serializedProject as string)).toEqual({
         version: 1,
-        nodes: editedNodes,
+        nodes: editedProjectNodes,
         connections: editedConnections,
       });
     } finally {
@@ -303,7 +305,7 @@ describe("useProjectFileWorkflow", () => {
   it("resets the project, closes the menu, and clears editor workflow state", () => {
     render(
       <WorkflowHarness
-        initialGraphNodes={editedNodes}
+        initialGraphNodes={editedProjectNodes}
         initialGraphConnections={editedConnections}
       />,
     );

--- a/src/useProjectFileWorkflow.ts
+++ b/src/useProjectFileWorkflow.ts
@@ -28,7 +28,7 @@ type UseProjectFileWorkflowOptions = {
 };
 
 export function readTextFile(file: File) {
-  if (file.text) {
+  if (typeof file.text === "function") {
     return file.text().then((result: unknown) => {
       if (typeof result === "string") {
         return result;

--- a/src/useProjectFileWorkflow.ts
+++ b/src/useProjectFileWorkflow.ts
@@ -29,7 +29,13 @@ type UseProjectFileWorkflowOptions = {
 
 export function readTextFile(file: File) {
   if (file.text) {
-    return file.text();
+    return file.text().then((result: unknown) => {
+      if (typeof result === "string") {
+        return result;
+      }
+
+      throw new Error("Project file could not be read as text.");
+    });
   }
 
   return new Promise<string>((resolve, reject) => {

--- a/src/useProjectFileWorkflow.ts
+++ b/src/useProjectFileWorkflow.ts
@@ -1,0 +1,183 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+import {
+  createProjectFile,
+  parseProjectFileContent,
+  serializeProjectFile,
+} from "./projectFile";
+import type { GraphConnection, GraphNode } from "./projectFile";
+
+type UseProjectFileWorkflowOptions = {
+  graphNodes: GraphNode[];
+  graphConnections: GraphConnection[];
+  setGraphNodes: Dispatch<SetStateAction<GraphNode[]>>;
+  setGraphConnections: Dispatch<SetStateAction<GraphConnection[]>>;
+  createInitialGraphNodes: () => GraphNode[];
+  clearSelectedNode: () => void;
+  clearConnectionSource: () => void;
+  clearConnectionFeedback: () => void;
+  clearDraggedNode: () => void;
+};
+
+export function readTextFile(file: File) {
+  if (file.text) {
+    return file.text();
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+
+      reject(new Error("Project file could not be read as text."));
+    });
+
+    reader.addEventListener("error", () => {
+      reject(new Error("Project file could not be read."));
+    });
+
+    reader.readAsText(file);
+  });
+}
+
+export function useProjectFileWorkflow({
+  graphNodes,
+  graphConnections,
+  setGraphNodes,
+  setGraphConnections,
+  createInitialGraphNodes,
+  clearSelectedNode,
+  clearConnectionSource,
+  clearConnectionFeedback,
+  clearDraggedNode,
+}: UseProjectFileWorkflowOptions) {
+  const [isProjectActionsOpen, setIsProjectActionsOpen] = useState(false);
+  const [projectToast, setProjectToast] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!projectToast) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setProjectToast(null);
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [projectToast]);
+
+  const clearEditorWorkflowState = useCallback(() => {
+    clearSelectedNode();
+    clearConnectionSource();
+    clearConnectionFeedback();
+    clearDraggedNode();
+  }, [
+    clearSelectedNode,
+    clearConnectionSource,
+    clearConnectionFeedback,
+    clearDraggedNode,
+  ]);
+
+  const toggleProjectActions = useCallback(() => {
+    setIsProjectActionsOpen((isOpen) => !isOpen);
+  }, []);
+
+  const openProjectImportPicker = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const exportProjectFile = useCallback(() => {
+    const project = createProjectFile(graphNodes, graphConnections);
+    const serializedProject = serializeProjectFile(project);
+    const projectBlob = new Blob([serializedProject], {
+      type: "application/json",
+    });
+    const projectUrl = URL.createObjectURL(projectBlob);
+    const projectLink = document.createElement("a");
+
+    projectLink.href = projectUrl;
+    projectLink.download = "dl-graph-studio-project.json";
+    document.body.append(projectLink);
+    projectLink.click();
+    projectLink.remove();
+    URL.revokeObjectURL(projectUrl);
+    setProjectToast("Project exported.");
+    setIsProjectActionsOpen(false);
+  }, [graphNodes, graphConnections]);
+
+  const importProjectFile = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const selectedFile = event.target.files?.[0];
+
+      if (!selectedFile) {
+        return;
+      }
+
+      let projectFileContent: string;
+
+      try {
+        projectFileContent = await readTextFile(selectedFile);
+      } catch {
+        setProjectToast("Project file could not be read.");
+        event.target.value = "";
+        return;
+      }
+
+      const parsedProject = parseProjectFileContent(projectFileContent);
+
+      if (!parsedProject.ok) {
+        setProjectToast(parsedProject.message);
+        event.target.value = "";
+        return;
+      }
+
+      setGraphNodes(parsedProject.project.nodes);
+      setGraphConnections(parsedProject.project.connections);
+      clearEditorWorkflowState();
+      setProjectToast("Project imported.");
+      setIsProjectActionsOpen(false);
+      event.target.value = "";
+    },
+    [setGraphNodes, setGraphConnections, clearEditorWorkflowState],
+  );
+
+  const resetProject = useCallback(() => {
+    setGraphNodes(createInitialGraphNodes());
+    setGraphConnections([]);
+    clearEditorWorkflowState();
+    setProjectToast("Project reset.");
+    setIsProjectActionsOpen(false);
+  }, [
+    setGraphNodes,
+    setGraphConnections,
+    createInitialGraphNodes,
+    clearEditorWorkflowState,
+  ]);
+
+  return {
+    isProjectActionsOpen,
+    setIsProjectActionsOpen,
+    toggleProjectActions,
+    projectToast,
+    fileInputRef,
+    openProjectImportPicker,
+    exportProjectFile,
+    importProjectFile,
+    resetProject,
+  };
+}


### PR DESCRIPTION
## Summary

- Extracted project import/export/reset orchestration from `src/App.tsx` into `useProjectFileWorkflow`.
- Moved project action menu state, file input ownership, project toasts, file reading, and browser download side effects behind the hook boundary.
- Added focused hook coverage, including successful import/reset cleanup of dragged-node state and failed import preservation.

## Linked issue

Closes #35

## Verification

Automated:

- [x] `pnpm test` - 5 files, 44 tests passed.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `pnpm format:check` - passed.

Manual:

- [x] Opened the app and confirmed primitive and composite nodes render.
- [x] Exported the current project from the project actions menu.
- [x] Imported a valid project file and confirmed the canvas updates without errors.
- [x] Reset the project and confirmed the default graph returns.
- [x] Edited a node parameter and confirmed inspector/node card updates.
- [x] Created a connection and confirmed it renders.
- [x] Imported invalid JSON and confirmed the toast error appears without breaking current state.

## Screenshots / video

Not applicable: this PR refactors project workflow ownership and preserves the existing UI.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI screenshots/video are not applicable because this PR preserves the existing UI.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- The persisted project shape in `src/projectFile.ts` is unchanged.
- Successful import/reset now also clear dragged-node state as an explicit scoped bug fix; failed imports preserve current editor state.