### PR TITLE
[codex] Collapse connections panel

### DIFF
--- a/docs/superpowers/plans/2026-05-05-connections-panel-space-management.md
+++ b/docs/superpowers/plans/2026-05-05-connections-panel-space-management.md
@@ -1,0 +1,445 @@
+# Connections Panel Space Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the bottom graph connections drawer collapsible and expandable while preserving existing connection behavior.
+
+**Architecture:** Keep the panel state local to `src/App.tsx` because the collapse state is session-only UI state and does not belong in the graph project model. Extend the existing drawer markup with a semantic toggle button, hide only the list body when collapsed, and let the current grid layout reclaim vertical space. Add focused tests around default expanded state, collapse persistence while adding connections, re-expansion, and delete behavior.
+
+**Tech Stack:** React, TypeScript, Vite, Vitest, React Testing Library, lucide-react, CSS.
+
+---
+
+## File Structure
+
+- Modify `src/App.test.tsx`: add focused tests for the connections drawer toggle behavior near the existing connection tests.
+- Modify `src/App.tsx`: add local collapse state, accessible toggle labels, conditional list rendering, and one lucide icon import.
+- Modify `src/styles.css`: update drawer header layout and add compact toggle button styles.
+
+No new runtime files, hooks, dependencies, or project-model changes are needed.
+
+---
+
+### Task 1: Add Failing Tests For Collapse Behavior
+
+**Files:**
+- Modify: `src/App.test.tsx`
+
+- [ ] **Step 1: Add the collapse behavior test after `creates visible in-memory connections between primitive nodes`**
+
+Insert this test immediately after the existing test that starts at `src/App.test.tsx:291`:
+
+```tsx
+  it("collapses and expands the connections panel without losing existing connections", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+    const connectionPanel = screen.getByLabelText(/graph connections/i);
+    const collapseButton = within(connectionPanel).getByRole("button", {
+      name: /collapse connections panel/i,
+    });
+
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+    expect(within(connectionPanel).getByText("Tensor -> Neuron")).toBeInTheDocument();
+
+    fireEvent.click(collapseButton);
+
+    const expandButton = within(connectionPanel).getByRole("button", {
+      name: /expand connections panel/i,
+    });
+
+    expect(expandButton).toHaveAttribute("aria-expanded", "false");
+    expect(
+      within(connectionPanel).queryByText("Tensor -> Neuron"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(expandButton);
+
+    expect(
+      within(connectionPanel).getByText("Tensor -> Neuron"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectionPanel).getByRole("button", {
+        name: /delete connection tensor to neuron/i,
+      }),
+    ).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Add the collapsed-state persistence test after the test from Step 1**
+
+Insert this second test immediately after the first new test:
+
+```tsx
+  it("keeps the connections panel collapsed when new connections are added", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+    const connectionPanel = screen.getByLabelText(/graph connections/i);
+    fireEvent.click(
+      within(connectionPanel).getByRole("button", {
+        name: /collapse connections panel/i,
+      }),
+    );
+
+    fireEvent.click(screen.getByLabelText(/start connection from neuron/i));
+    fireEvent.click(screen.getByLabelText(/connect neuron to activation/i));
+
+    expect(
+      within(connectionPanel).getByRole("button", {
+        name: /expand connections panel/i,
+      }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(within(connectionPanel).getByText("2")).toBeInTheDocument();
+    expect(
+      within(connectionPanel).queryByText("Tensor -> Neuron"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(connectionPanel).queryByText("Neuron -> Activation"),
+    ).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 3: Run the focused tests and verify they fail for the missing toggle**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "connections panel"
+```
+
+Expected: FAIL because no button named `Collapse connections panel` exists yet.
+
+---
+
+### Task 2: Implement The Connections Drawer Toggle
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Import a compact expand/collapse icon**
+
+Update the lucide import in `src/App.tsx` so it includes `ChevronDown`.
+
+Expected import excerpt:
+
+```tsx
+import {
+  AlertTriangle,
+  BookOpen,
+  Box,
+  ChevronDown,
+  ChevronsRight,
+  CircuitBoard,
+  Grid,
+  Hand,
+  Info,
+  Link2,
+  MousePointer2,
+  Play,
+  RotateCcw,
+  Save,
+  Settings,
+  Share2,
+  SlidersHorizontal,
+  Trash2,
+  Undo2,
+  Redo2,
+  X,
+  MoreVertical,
+  Download,
+  Upload,
+} from "lucide-react";
+```
+
+- [ ] **Step 2: Add local UI state in `App`**
+
+Add this state after the existing `connectionSourceId` state in `src/App.tsx`:
+
+```tsx
+  const [isConnectionsPanelCollapsed, setIsConnectionsPanelCollapsed] =
+    useState(false);
+```
+
+The surrounding state block should read:
+
+```tsx
+  const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
+    null,
+  );
+  const [isConnectionsPanelCollapsed, setIsConnectionsPanelCollapsed] =
+    useState(false);
+  const graphCanvasRef = useRef<HTMLElement | null>(null);
+```
+
+- [ ] **Step 3: Add a toggle label constant before the JSX return**
+
+Add this constant after `canvasEdges` is computed and before `return (`. If `canvasEdges` is already near the JSX return, keep this local to the render preparation area:
+
+```tsx
+  const connectionsPanelToggleLabel = isConnectionsPanelCollapsed
+    ? "Expand connections panel"
+    : "Collapse connections panel";
+```
+
+- [ ] **Step 4: Replace the connections drawer markup**
+
+Replace the current block that starts with `{canvasEdges.length > 0 ? (` and renders `<section className="connection-drawer" aria-label="Graph connections">` with this markup:
+
+```tsx
+          {canvasEdges.length > 0 ? (
+            <section
+              className={`connection-drawer${isConnectionsPanelCollapsed ? " collapsed" : ""}`}
+              aria-label="Graph connections"
+            >
+              <header className="connection-drawer-header">
+                <div className="connection-drawer-summary">
+                  <h3>Connections</h3>
+                  <span>{graphConnections.length}</span>
+                </div>
+                <button
+                  type="button"
+                  className="connection-drawer-toggle"
+                  aria-expanded={!isConnectionsPanelCollapsed}
+                  aria-label={connectionsPanelToggleLabel}
+                  title={connectionsPanelToggleLabel}
+                  onClick={() =>
+                    setIsConnectionsPanelCollapsed(
+                      (currentIsCollapsed) => !currentIsCollapsed,
+                    )
+                  }
+                >
+                  <ChevronDown size={16} aria-hidden="true" />
+                </button>
+              </header>
+              {!isConnectionsPanelCollapsed ? (
+                <div className="connection-list">
+                  {graphConnections.map((connection) => {
+                    const connectionLabel = getGraphConnectionLabel(
+                      connection,
+                      graphNodes,
+                    );
+
+                    return (
+                      <div className="connection-list-item" key={connection.id}>
+                        <span>{connectionLabel}</span>
+                        <button
+                          type="button"
+                          className="connection-delete-button"
+                          aria-label={getDeleteConnectionLabel(connectionLabel)}
+                          title={getDeleteConnectionLabel(connectionLabel)}
+                          onClick={() => deleteGraphConnection(connection.id)}
+                        >
+                          <Trash2 size={13} aria-hidden="true" />
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+```
+
+- [ ] **Step 5: Run the focused tests**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "connections panel"
+```
+
+Expected: PASS for the two new tests. If the command also runs unrelated tests whose names match the filter, they should remain PASS.
+
+---
+
+### Task 3: Style The Compact Drawer State
+
+**Files:**
+- Modify: `src/styles.css`
+
+- [ ] **Step 1: Update the drawer header styles**
+
+Replace the existing `.connection-drawer-header` block and `.connection-drawer-header span` block with:
+
+```css
+.connection-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 38px;
+  padding: 0 8px 0 12px;
+  border-bottom: 1px solid var(--surface-muted);
+}
+
+.connection-drawer.collapsed .connection-drawer-header {
+  border-bottom: 0;
+}
+
+.connection-drawer-summary {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.connection-drawer-summary h3 {
+  margin: 0;
+}
+
+.connection-drawer-summary span {
+  display: inline-grid;
+  min-width: 20px;
+  height: 20px;
+  place-items: center;
+  color: #ffffff;
+  background: var(--teal-strong);
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+```
+
+- [ ] **Step 2: Add toggle button styles before `.connection-list`**
+
+Insert this CSS before the existing `.connection-list` block:
+
+```css
+.connection-drawer-toggle {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--teal-strong);
+  background: var(--teal-soft);
+  border: 1px solid rgba(19, 168, 158, 0.25);
+  border-radius: 7px;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
+}
+
+.connection-drawer-toggle:hover,
+.connection-drawer-toggle:focus-visible {
+  color: #ffffff;
+  background: var(--teal);
+  outline: none;
+  box-shadow: 0 0 0 3px rgb(19 168 158 / 20%);
+}
+
+.connection-drawer.collapsed .connection-drawer-toggle svg {
+  transform: rotate(180deg);
+}
+```
+
+- [ ] **Step 3: Run the focused tests again**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "connections panel"
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Run Full Verification
+
+**Files:**
+- Verify: `src/App.test.tsx`
+- Verify: `src/App.tsx`
+- Verify: `src/styles.css`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```bash
+pnpm lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run formatting check if available**
+
+Run:
+
+```bash
+pnpm format:check
+```
+
+Expected: PASS if the script exists. If the script does not exist, record the exact package manager error and continue with the issue-required checks from Steps 1-3.
+
+- [ ] **Step 5: Inspect the final diff**
+
+Run:
+
+```bash
+git diff -- src/App.test.tsx src/App.tsx src/styles.css
+```
+
+Expected: diff only covers the connections drawer tests, local collapsed state, drawer toggle markup, and drawer styles.
+
+- [ ] **Step 6: Commit the implementation**
+
+Run:
+
+```bash
+git add src/App.test.tsx src/App.tsx src/styles.css
+git commit -m "feat: collapse connections panel"
+```
+
+Expected: commit succeeds with only the implementation files staged.
+
+---
+
+## Manual Verification Notes For The PR
+
+After implementation, run `pnpm dev`, open the editor, and verify:
+
+1. Create `Tensor -> Neuron`; the connections drawer appears expanded.
+2. Collapse the drawer; only the compact header remains and the canvas has more vertical room.
+3. Add `Neuron -> Activation`; the drawer remains collapsed and the count changes to `2`.
+4. Expand the drawer; both connection rows are visible.
+5. Delete one connection; the remaining row stays visible and existing delete feedback still appears.
+6. Resize to a narrower viewport; the toggle remains reachable.
+
+Capture screenshots or a short recording of expanded and collapsed states for the pull request.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers default expanded behavior, session-only collapsed state, no persistence, no model changes, accessible toggle state, compact styling, tests, and issue-required verification.
+- Placeholder scan: No placeholder tokens, deferred-work markers, or vague edge-case instructions remain.
+- Type consistency: The plan uses one boolean state, `isConnectionsPanelCollapsed`, one setter, `setIsConnectionsPanelCollapsed`, and one render-local label constant, `connectionsPanelToggleLabel`, consistently across code and tests.

--- a/docs/superpowers/plans/2026-05-05-connections-panel-space-management.md
+++ b/docs/superpowers/plans/2026-05-05-connections-panel-space-management.md
@@ -23,6 +23,7 @@ No new runtime files, hooks, dependencies, or project-model changes are needed.
 ### Task 1: Add Failing Tests For Collapse Behavior
 
 **Files:**
+
 - Modify: `src/App.test.tsx`
 
 - [ ] **Step 1: Add the collapse behavior test after `creates visible in-memory connections between primitive nodes`**
@@ -30,42 +31,44 @@ No new runtime files, hooks, dependencies, or project-model changes are needed.
 Insert this test immediately after the existing test that starts at `src/App.test.tsx:291`:
 
 ```tsx
-  it("collapses and expands the connections panel without losing existing connections", () => {
-    render(<App />);
+it("collapses and expands the connections panel without losing existing connections", () => {
+  render(<App />);
 
-    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
-    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
 
-    const connectionPanel = screen.getByLabelText(/graph connections/i);
-    const collapseButton = within(connectionPanel).getByRole("button", {
-      name: /collapse connections panel/i,
-    });
-
-    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
-    expect(within(connectionPanel).getByText("Tensor -> Neuron")).toBeInTheDocument();
-
-    fireEvent.click(collapseButton);
-
-    const expandButton = within(connectionPanel).getByRole("button", {
-      name: /expand connections panel/i,
-    });
-
-    expect(expandButton).toHaveAttribute("aria-expanded", "false");
-    expect(
-      within(connectionPanel).queryByText("Tensor -> Neuron"),
-    ).not.toBeInTheDocument();
-
-    fireEvent.click(expandButton);
-
-    expect(
-      within(connectionPanel).getByText("Tensor -> Neuron"),
-    ).toBeInTheDocument();
-    expect(
-      within(connectionPanel).getByRole("button", {
-        name: /delete connection tensor to neuron/i,
-      }),
-    ).toBeInTheDocument();
+  const connectionPanel = screen.getByLabelText(/graph connections/i);
+  const collapseButton = within(connectionPanel).getByRole("button", {
+    name: /collapse connections panel/i,
   });
+
+  expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+  expect(
+    within(connectionPanel).getByText("Tensor -> Neuron"),
+  ).toBeInTheDocument();
+
+  fireEvent.click(collapseButton);
+
+  const expandButton = within(connectionPanel).getByRole("button", {
+    name: /expand connections panel/i,
+  });
+
+  expect(expandButton).toHaveAttribute("aria-expanded", "false");
+  expect(
+    within(connectionPanel).queryByText("Tensor -> Neuron"),
+  ).not.toBeInTheDocument();
+
+  fireEvent.click(expandButton);
+
+  expect(
+    within(connectionPanel).getByText("Tensor -> Neuron"),
+  ).toBeInTheDocument();
+  expect(
+    within(connectionPanel).getByRole("button", {
+      name: /delete connection tensor to neuron/i,
+    }),
+  ).toBeInTheDocument();
+});
 ```
 
 - [ ] **Step 2: Add the collapsed-state persistence test after the test from Step 1**
@@ -73,35 +76,35 @@ Insert this test immediately after the existing test that starts at `src/App.tes
 Insert this second test immediately after the first new test:
 
 ```tsx
-  it("keeps the connections panel collapsed when new connections are added", () => {
-    render(<App />);
+it("keeps the connections panel collapsed when new connections are added", () => {
+  render(<App />);
 
-    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
-    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
 
-    const connectionPanel = screen.getByLabelText(/graph connections/i);
-    fireEvent.click(
-      within(connectionPanel).getByRole("button", {
-        name: /collapse connections panel/i,
-      }),
-    );
+  const connectionPanel = screen.getByLabelText(/graph connections/i);
+  fireEvent.click(
+    within(connectionPanel).getByRole("button", {
+      name: /collapse connections panel/i,
+    }),
+  );
 
-    fireEvent.click(screen.getByLabelText(/start connection from neuron/i));
-    fireEvent.click(screen.getByLabelText(/connect neuron to activation/i));
+  fireEvent.click(screen.getByLabelText(/start connection from neuron/i));
+  fireEvent.click(screen.getByLabelText(/connect neuron to activation/i));
 
-    expect(
-      within(connectionPanel).getByRole("button", {
-        name: /expand connections panel/i,
-      }),
-    ).toHaveAttribute("aria-expanded", "false");
-    expect(within(connectionPanel).getByText("2")).toBeInTheDocument();
-    expect(
-      within(connectionPanel).queryByText("Tensor -> Neuron"),
-    ).not.toBeInTheDocument();
-    expect(
-      within(connectionPanel).queryByText("Neuron -> Activation"),
-    ).not.toBeInTheDocument();
-  });
+  expect(
+    within(connectionPanel).getByRole("button", {
+      name: /expand connections panel/i,
+    }),
+  ).toHaveAttribute("aria-expanded", "false");
+  expect(within(connectionPanel).getByText("2")).toBeInTheDocument();
+  expect(
+    within(connectionPanel).queryByText("Tensor -> Neuron"),
+  ).not.toBeInTheDocument();
+  expect(
+    within(connectionPanel).queryByText("Neuron -> Activation"),
+  ).not.toBeInTheDocument();
+});
 ```
 
 - [ ] **Step 3: Run the focused tests and verify they fail for the missing toggle**
@@ -119,6 +122,7 @@ Expected: FAIL because no button named `Collapse connections panel` exists yet.
 ### Task 2: Implement The Connections Drawer Toggle
 
 **Files:**
+
 - Modify: `src/App.tsx`
 
 - [ ] **Step 1: Import a compact expand/collapse icon**
@@ -161,19 +165,19 @@ import {
 Add this state after the existing `connectionSourceId` state in `src/App.tsx`:
 
 ```tsx
-  const [isConnectionsPanelCollapsed, setIsConnectionsPanelCollapsed] =
-    useState(false);
+const [isConnectionsPanelCollapsed, setIsConnectionsPanelCollapsed] =
+  useState(false);
 ```
 
 The surrounding state block should read:
 
 ```tsx
-  const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
-    null,
-  );
-  const [isConnectionsPanelCollapsed, setIsConnectionsPanelCollapsed] =
-    useState(false);
-  const graphCanvasRef = useRef<HTMLElement | null>(null);
+const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
+  null,
+);
+const [isConnectionsPanelCollapsed, setIsConnectionsPanelCollapsed] =
+  useState(false);
+const graphCanvasRef = useRef<HTMLElement | null>(null);
 ```
 
 - [ ] **Step 3: Add a toggle label constant before the JSX return**
@@ -181,9 +185,9 @@ The surrounding state block should read:
 Add this constant after `canvasEdges` is computed and before `return (`. If `canvasEdges` is already near the JSX return, keep this local to the render preparation area:
 
 ```tsx
-  const connectionsPanelToggleLabel = isConnectionsPanelCollapsed
-    ? "Expand connections panel"
-    : "Collapse connections panel";
+const connectionsPanelToggleLabel = isConnectionsPanelCollapsed
+  ? "Expand connections panel"
+  : "Collapse connections panel";
 ```
 
 - [ ] **Step 4: Replace the connections drawer markup**
@@ -191,58 +195,60 @@ Add this constant after `canvasEdges` is computed and before `return (`. If `can
 Replace the current block that starts with `{canvasEdges.length > 0 ? (` and renders `<section className="connection-drawer" aria-label="Graph connections">` with this markup:
 
 ```tsx
-          {canvasEdges.length > 0 ? (
-            <section
-              className={`connection-drawer${isConnectionsPanelCollapsed ? " collapsed" : ""}`}
-              aria-label="Graph connections"
-            >
-              <header className="connection-drawer-header">
-                <div className="connection-drawer-summary">
-                  <h3>Connections</h3>
-                  <span>{graphConnections.length}</span>
-                </div>
+{
+  canvasEdges.length > 0 ? (
+    <section
+      className={`connection-drawer${isConnectionsPanelCollapsed ? " collapsed" : ""}`}
+      aria-label="Graph connections"
+    >
+      <header className="connection-drawer-header">
+        <div className="connection-drawer-summary">
+          <h3>Connections</h3>
+          <span>{graphConnections.length}</span>
+        </div>
+        <button
+          type="button"
+          className="connection-drawer-toggle"
+          aria-expanded={!isConnectionsPanelCollapsed}
+          aria-label={connectionsPanelToggleLabel}
+          title={connectionsPanelToggleLabel}
+          onClick={() =>
+            setIsConnectionsPanelCollapsed(
+              (currentIsCollapsed) => !currentIsCollapsed,
+            )
+          }
+        >
+          <ChevronDown size={16} aria-hidden="true" />
+        </button>
+      </header>
+      {!isConnectionsPanelCollapsed ? (
+        <div className="connection-list">
+          {graphConnections.map((connection) => {
+            const connectionLabel = getGraphConnectionLabel(
+              connection,
+              graphNodes,
+            );
+
+            return (
+              <div className="connection-list-item" key={connection.id}>
+                <span>{connectionLabel}</span>
                 <button
                   type="button"
-                  className="connection-drawer-toggle"
-                  aria-expanded={!isConnectionsPanelCollapsed}
-                  aria-label={connectionsPanelToggleLabel}
-                  title={connectionsPanelToggleLabel}
-                  onClick={() =>
-                    setIsConnectionsPanelCollapsed(
-                      (currentIsCollapsed) => !currentIsCollapsed,
-                    )
-                  }
+                  className="connection-delete-button"
+                  aria-label={getDeleteConnectionLabel(connectionLabel)}
+                  title={getDeleteConnectionLabel(connectionLabel)}
+                  onClick={() => deleteGraphConnection(connection.id)}
                 >
-                  <ChevronDown size={16} aria-hidden="true" />
+                  <Trash2 size={13} aria-hidden="true" />
                 </button>
-              </header>
-              {!isConnectionsPanelCollapsed ? (
-                <div className="connection-list">
-                  {graphConnections.map((connection) => {
-                    const connectionLabel = getGraphConnectionLabel(
-                      connection,
-                      graphNodes,
-                    );
-
-                    return (
-                      <div className="connection-list-item" key={connection.id}>
-                        <span>{connectionLabel}</span>
-                        <button
-                          type="button"
-                          className="connection-delete-button"
-                          aria-label={getDeleteConnectionLabel(connectionLabel)}
-                          title={getDeleteConnectionLabel(connectionLabel)}
-                          onClick={() => deleteGraphConnection(connection.id)}
-                        >
-                          <Trash2 size={13} aria-hidden="true" />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : null}
-            </section>
-          ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
+  ) : null;
+}
 ```
 
 - [ ] **Step 5: Run the focused tests**
@@ -260,6 +266,7 @@ Expected: PASS for the two new tests. If the command also runs unrelated tests w
 ### Task 3: Style The Compact Drawer State
 
 **Files:**
+
 - Modify: `src/styles.css`
 
 - [ ] **Step 1: Update the drawer header styles**
@@ -356,6 +363,7 @@ Expected: PASS.
 ### Task 4: Run Full Verification
 
 **Files:**
+
 - Verify: `src/App.test.tsx`
 - Verify: `src/App.tsx`
 - Verify: `src/styles.css`

--- a/docs/superpowers/specs/2026-05-05-connections-panel-space-management-design.md
+++ b/docs/superpowers/specs/2026-05-05-connections-panel-space-management-design.md
@@ -1,0 +1,108 @@
+# Connections Panel Space Management Design
+
+## Context
+
+Issue #32 covers a Phase 1 UX improvement for the graph editor: the bottom
+connections list should be collapsible so it does not permanently consume
+editor space when the user does not need to inspect individual connections.
+
+The current editor renders the connections drawer only when at least one
+connection exists. When rendered, the drawer is always expanded and shows a
+header, connection count, scrollable list, and per-connection delete buttons.
+The surrounding editor layout already uses a grid where the bottom drawer
+occupies an `auto` row, so reducing the drawer to a compact header lets the
+canvas row reclaim vertical space without a broad layout rewrite.
+
+## Goal
+
+Add a small, explicit collapse and expand interaction to the bottom connections
+drawer while preserving all existing connection behavior when the drawer is
+expanded.
+
+The drawer should be expanded by default when it first appears in a session. If
+the user collapses it, that manual choice should remain in effect while the app
+session continues, including when new connections are added.
+
+## Non-Goals
+
+- Do not change connection creation, deletion, validation, persistence, labels,
+  sorting, filtering, or editing behavior.
+- Do not change the graph data model or saved project shape.
+- Do not persist the collapsed state across reloads.
+- Do not redesign the full editor layout or replace the existing drawer pattern.
+- Do not add new dependencies.
+
+## Recommended Design
+
+Use local UI state in `src/App.tsx` to track whether the connections drawer is
+collapsed. The state should initialize to expanded and only change when the user
+activates the drawer toggle.
+
+The drawer should continue to render only when there is at least one connection.
+Its header remains visible in both states and includes:
+
+- the existing `Connections` title,
+- the current connection count,
+- a real button for expanding or collapsing the drawer.
+
+When expanded, the drawer shows the existing connection list and delete buttons
+with the current behavior unchanged. When collapsed, the drawer hides the list
+body and keeps only the compact header visible. Adding a connection while the
+drawer is collapsed updates the count but does not automatically expand the
+drawer.
+
+## Accessibility
+
+The toggle should be a semantic button, not a styled non-interactive element.
+It should expose the drawer state with `aria-expanded` and use a clear
+accessible label such as `Collapse connections panel` when expanded and
+`Expand connections panel` when collapsed.
+
+The existing `Graph connections` accessible region should remain stable so
+current tests and assistive navigation continue to have a predictable target.
+When collapsed, the list content should not remain exposed as visible
+connection rows.
+
+## Styling
+
+The implementation should extend the current drawer styles instead of creating a
+new panel system. The collapsed state should reduce the drawer to its header so
+the editor grid can allocate the reclaimed space to the canvas area.
+
+The toggle affordance should fit the existing Phase 1 visual system: compact,
+clear, and reachable at desktop and narrower responsive widths. The change
+should avoid nested cards, broad palette changes, or decorative layout work.
+
+## Testing
+
+Add focused tests in `src/App.test.tsx` for the new panel behavior:
+
+- a connection makes the drawer appear expanded by default and the connection
+  row is visible,
+- activating the toggle collapses the drawer and sets `aria-expanded` to
+  `false`,
+- adding another connection while collapsed keeps the drawer collapsed while the
+  count updates,
+- expanding again reveals the connection rows and preserves existing delete
+  behavior.
+
+Existing tests for connection creation, deletion, reset, import/export,
+parameter editing, and node dragging should continue to pass without requiring
+behavioral changes outside the panel surface.
+
+## Verification
+
+Automated verification should follow issue #32:
+
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+Manual verification should start the app with `pnpm dev`, open the graph
+editor, create at least one connection, collapse the drawer, confirm the canvas
+area gains usable space, add another connection while the drawer remains
+collapsed, expand the drawer, and confirm the connection rows and delete action
+still behave as before.
+
+The pull request should include screenshots or a short recording showing the
+expanded and collapsed states.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -33,6 +33,17 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+function expectConnectionLabelHidden(container: HTMLElement, label: string) {
+  const connectionLabel = within(container).queryByText(label);
+
+  if (connectionLabel) {
+    expect(connectionLabel).not.toBeVisible();
+    return;
+  }
+
+  expect(connectionLabel).not.toBeInTheDocument();
+}
+
 describe("App shell", () => {
   it("renders the graph studio workspace shell", () => {
     render(<App />);
@@ -298,6 +309,69 @@ describe("App shell", () => {
 
     expect(screen.getByText("Tensor -> Neuron")).toBeInTheDocument();
     expect(screen.getByText("Neuron -> Activation")).toBeInTheDocument();
+  });
+
+  it("collapses and expands the connections panel without losing existing connections", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+    const connectionPanel = screen.getByLabelText(/graph connections/i);
+    const collapseButton = within(connectionPanel).getByRole("button", {
+      name: /collapse connections panel/i,
+    });
+
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+    expect(
+      within(connectionPanel).getByText("Tensor -> Neuron"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(collapseButton);
+
+    const expandButton = within(connectionPanel).getByRole("button", {
+      name: /expand connections panel/i,
+    });
+
+    expect(expandButton).toHaveAttribute("aria-expanded", "false");
+    expectConnectionLabelHidden(connectionPanel, "Tensor -> Neuron");
+
+    fireEvent.click(expandButton);
+
+    expect(
+      within(connectionPanel).getByText("Tensor -> Neuron"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectionPanel).getByRole("button", {
+        name: /delete connection tensor to neuron/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the connections panel collapsed when new connections are added", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+    const connectionPanel = screen.getByLabelText(/graph connections/i);
+    fireEvent.click(
+      within(connectionPanel).getByRole("button", {
+        name: /collapse connections panel/i,
+      }),
+    );
+
+    fireEvent.click(screen.getByLabelText(/start connection from neuron/i));
+    fireEvent.click(screen.getByLabelText(/connect neuron to activation/i));
+
+    expect(
+      within(connectionPanel).getByRole("button", {
+        name: /expand connections panel/i,
+      }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(within(connectionPanel).getByText("2")).toBeInTheDocument();
+    expectConnectionLabelHidden(connectionPanel, "Tensor -> Neuron");
+    expectConnectionLabelHidden(connectionPanel, "Neuron -> Activation");
   });
 
   it("deletes one chosen connection while preserving nodes and other connections", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import {
   AlertTriangle,
   BookOpen,
   Box,
+  ChevronDown,
   ChevronsRight,
   CircuitBoard,
   Grid,
@@ -545,6 +546,8 @@ export function App() {
   const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
     null,
   );
+  const [isConnectionsPanelCollapsed, setIsConnectionsPanelCollapsed] =
+    useState(false);
   const graphCanvasRef = useRef<HTMLElement | null>(null);
   const [canvasNodeExtent, setCanvasNodeExtent] =
     useState<CoordinateExtent | null>(null);
@@ -882,6 +885,10 @@ export function App() {
     [graphConnections, graphNodes],
   );
 
+  const connectionsPanelToggleLabel = isConnectionsPanelCollapsed
+    ? "Expand connections panel"
+    : "Collapse connections panel";
+
   return (
     <div className="app-shell">
       <header className="app-topbar">
@@ -1110,36 +1117,59 @@ export function App() {
 
           {canvasEdges.length > 0 ? (
             <section
-              className="connection-drawer"
+              className={`connection-drawer${isConnectionsPanelCollapsed ? " collapsed" : ""}`}
               aria-label="Graph connections"
             >
               <header className="connection-drawer-header">
-                <h3>Connections</h3>
-                <span>{graphConnections.length}</span>
+                <div className="connection-drawer-summary">
+                  <h3>Connections</h3>
+                  <span>{graphConnections.length}</span>
+                </div>
+                <button
+                  type="button"
+                  className="connection-drawer-toggle"
+                  aria-expanded={!isConnectionsPanelCollapsed}
+                  aria-label={connectionsPanelToggleLabel}
+                  title={connectionsPanelToggleLabel}
+                  onClick={() =>
+                    setIsConnectionsPanelCollapsed(
+                      (currentIsCollapsed) => !currentIsCollapsed,
+                    )
+                  }
+                >
+                  <ChevronDown size={16} aria-hidden="true" />
+                </button>
               </header>
-              <div className="connection-list">
-                {graphConnections.map((connection) => {
-                  const connectionLabel = getGraphConnectionLabel(
-                    connection,
-                    graphNodes,
-                  );
+              {!isConnectionsPanelCollapsed ? (
+                <div className="connection-list">
+                  {graphConnections.map((connection) => {
+                    const connectionLabel = getGraphConnectionLabel(
+                      connection,
+                      graphNodes,
+                    );
 
-                  return (
-                    <div className="connection-list-item" key={connection.id}>
-                      <span>{connectionLabel}</span>
-                      <button
-                        type="button"
-                        className="connection-delete-button"
-                        aria-label={getDeleteConnectionLabel(connectionLabel)}
-                        title={getDeleteConnectionLabel(connectionLabel)}
-                        onClick={() => deleteGraphConnection(connection.id)}
+                    return (
+                      <div
+                        className="connection-list-item"
+                        key={connection.id}
                       >
-                        <Trash2 size={13} aria-hidden="true" />
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
+                        <span>{connectionLabel}</span>
+                        <button
+                          type="button"
+                          className="connection-delete-button"
+                          aria-label={getDeleteConnectionLabel(
+                            connectionLabel,
+                          )}
+                          title={getDeleteConnectionLabel(connectionLabel)}
+                          onClick={() => deleteGraphConnection(connection.id)}
+                        >
+                          <Trash2 size={13} aria-hidden="true" />
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : null}
             </section>
           ) : null}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1149,17 +1149,12 @@ export function App() {
                     );
 
                     return (
-                      <div
-                        className="connection-list-item"
-                        key={connection.id}
-                      >
+                      <div className="connection-list-item" key={connection.id}>
                         <span>{connectionLabel}</span>
                         <button
                           type="button"
                           className="connection-delete-button"
-                          aria-label={getDeleteConnectionLabel(
-                            connectionLabel,
-                          )}
+                          aria-label={getDeleteConnectionLabel(connectionLabel)}
                           title={getDeleteConnectionLabel(connectionLabel)}
                           onClick={() => deleteGraphConnection(connection.id)}
                         >

--- a/src/styles.css
+++ b/src/styles.css
@@ -733,12 +733,28 @@ h4 {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 10px;
   min-height: 38px;
-  padding: 0 12px;
+  padding: 0 8px 0 12px;
   border-bottom: 1px solid var(--surface-muted);
 }
 
-.connection-drawer-header span {
+.connection-drawer.collapsed .connection-drawer-header {
+  border-bottom: 0;
+}
+
+.connection-drawer-summary {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.connection-drawer-summary h3 {
+  margin: 0;
+}
+
+.connection-drawer-summary span {
   display: inline-grid;
   min-width: 20px;
   height: 20px;
@@ -748,6 +764,36 @@ h4 {
   border-radius: 999px;
   font-size: 0.72rem;
   font-weight: 800;
+}
+
+.connection-drawer-toggle {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--teal-strong);
+  background: var(--teal-soft);
+  border: 1px solid rgba(19, 168, 158, 0.25);
+  border-radius: 7px;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
+}
+
+.connection-drawer-toggle:hover,
+.connection-drawer-toggle:focus-visible {
+  color: #ffffff;
+  background: var(--teal);
+  outline: none;
+  box-shadow: 0 0 0 3px rgb(19 168 158 / 20%);
+}
+
+.connection-drawer.collapsed .connection-drawer-toggle svg {
+  transform: rotate(180deg);
 }
 
 .connection-list {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1035,6 +1035,9 @@ h4 {
 @media (max-width: 820px) {
   .app-shell {
     grid-template-rows: auto auto;
+    height: auto;
+    min-height: 100vh;
+    overflow: auto;
   }
 
   .app-topbar {


### PR DESCRIPTION
## Summary

- Add a collapse/expand toggle to the bottom graph connections drawer.
- Keep the drawer expanded by default, preserve the user's collapsed state when new connections are added, and keep the connection count visible while collapsed.
- Add focused tests, compact drawer styling, and a responsive scroll fix so the drawer remains reachable on narrower viewports.

## Linked issue

Closes #32

## Verification

Automated:

- [x] `pnpm test` - passed, 5 test files / 46 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `pnpm format:check` - passed.
- [x] `git diff --check` - passed.

Manual:

- [x] Started the app with `pnpm dev --host 127.0.0.1`.
- [x] Created `Tensor -> Neuron`; the connections drawer appeared expanded by default.
- [x] Collapsed the drawer; only the compact header and count remained visible.
- [x] Added another connection while collapsed; the drawer stayed collapsed and the count updated to `2`.
- [x] Expanded the drawer again; both connection rows were visible.
- [x] Deleted one connection; the remaining connection stayed visible.
- [x] Verified the drawer is reachable at a narrow responsive viewport after scrolling.

## Screenshots / video

Screenshots captured locally:

- `output/playwright/connections-panel-collapsed-responsive.png`
- `output/playwright/connections-panel-expanded-responsive.png`

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- The collapse state is session-local UI state and is not persisted across reloads.
- The drawer list is unmounted while collapsed, so hidden connection rows and delete buttons are not exposed to assistive navigation.
