### PR TITLE
[Roadmap]: Phase 1 UX/UI hardening

### DIFF
--- a/docs/superpowers/plans/2026-05-05-phase-1-ux-ui-hardening.md
+++ b/docs/superpowers/plans/2026-05-05-phase-1-ux-ui-hardening.md
@@ -1,0 +1,866 @@
+# Phase 1 UX/UI Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the Phase 1 UX/UI closeout pass with approved baseline fixes, a visual review gate for newly discovered findings, and documented verification evidence.
+
+**Architecture:** Keep the hardening work inside the existing React app boundary. Use `src/App.tsx` for canvas interaction, React Flow adapter props, and connection feedback rendering; keep project import/export/reset toast behavior in `src/useProjectFileWorkflow.ts`; use `src/styles.css` only for small visual-system corrections approved for #22. Newly discovered visual findings must be listed and approved by the product owner before implementation.
+
+**Tech Stack:** React 19, TypeScript, Vite, React Flow (`@xyflow/react`), lucide-react, Vitest, React Testing Library, CSS, GitHub CLI.
+
+---
+
+## File Structure
+
+- Modify GitHub issue #22 before implementation:
+  - Keep the current issue body structure.
+  - Add the approved visual review gate from `docs/superpowers/specs/2026-05-05-phase-1-ux-ui-hardening-design.md`.
+  - Add the `ready` label and move the Project status to `Ready` only after the roadmap validator passes.
+- Modify `src/App.test.tsx`:
+  - Add focused tests for clearing node selection on empty canvas clicks.
+  - Add tests for unifying visible feedback surfaces where practical.
+  - Add tests that React Flow attribution handling is explicit in the adapter.
+- Modify `src/App.nodeDrag.test.tsx` only if React Flow mock coverage is needed for pane-click or attribution props.
+- Modify `src/App.tsx`:
+  - Add the empty-canvas click behavior through React Flow pane handling.
+  - Keep node, edge, port, control, and connection interactions intact.
+  - Add or adjust React Flow attribution configuration only if allowed by the installed package and license.
+  - Unify connection feedback with the existing toast/status pattern without changing graph behavior.
+- Modify `src/useProjectFileWorkflow.ts` only if toast timing, message naming, or shared toast semantics need a small focused adjustment.
+- Modify `src/styles.css`:
+  - Apply approved small visual corrections from the visual review list.
+  - Keep existing color system, density, and layout structure intact.
+- Create or update PR evidence files only if the repository already has an established local evidence path; otherwise attach screenshots or recording in the PR body instead of adding binary files.
+
+Do not add dependencies, new graph model fields, new product controls, persistence changes, broad `App.tsx` decomposition, or unapproved visual polish.
+
+---
+
+### Task 1: Prepare Issue #22 For Ready Status
+
+**Files:**
+
+- Read: `.github/ISSUE_TEMPLATE/roadmap-task.md`
+- Read: `docs/superpowers/specs/2026-05-05-phase-1-ux-ui-hardening-design.md`
+- External: GitHub issue #22 and `dl-graph-studio Roadmap` Project
+
+- [ ] **Step 1: Create a temporary issue body file from the approved design**
+
+Create `/tmp/phase-1-ux-ui-hardening-issue.md` with this exact body:
+
+```md
+## Objective
+
+Review and tighten the user-facing experience delivered by Phase 1 after the core architecture editor issues are complete, while keeping this issue as the Phase 1 UX/UI hardening umbrella, finding inbox, and final closeout pass.
+
+This issue is not a redesign bucket. Larger UX changes, new product capabilities, or work that would make the pull request too broad should be converted into focused follow-up roadmap issues.
+
+## Scope
+
+- Review the primary Phase 1 editor flow end-to-end now that the planned functional Phase 1 issues are complete.
+- Triage product-owner-reported UX/UI findings for Phase 1.
+- Fix the existing open #22 findings:
+  - unify toast notifications across the Phase 1 editor flow,
+  - remove the default React Flow attribution only if licensing and package configuration allow it,
+  - clear the active component selection when clicking the empty canvas background without interfering with nodes, ports, edges, or canvas controls.
+- Run a complete visual review of the Phase 1 editor flow and list small newly discovered visual or interaction findings.
+- Ask the product owner to approve newly discovered findings before correcting them.
+- Fix only newly discovered findings approved by the product owner for this PR.
+- Verify consistency between the canvas, inspector, toolbar, navigation, validation surfaces, and relevant empty/error states.
+- Capture screenshots or a short recording of the reviewed flow.
+- Create follow-up roadmap issue recommendations for larger UX or product problems found during review.
+
+## Out of scope
+
+- New product capabilities.
+- Large redesigns.
+- Broad refactors unrelated to the UX/UI hardening pass.
+- Dependency changes unless required for a scoped hardening fix.
+- Changes to future milestone behavior.
+- Treating unresolved product decisions as visual polish.
+- Reopening work already resolved in separate roadmap issues #26, #32, or #33.
+- Fixing newly discovered visual findings before product-owner approval.
+
+## Acceptance criteria
+
+- [ ] The primary Phase 1 flow has been reviewed end-to-end.
+- [ ] Product-owner-reported UX/UI findings for Phase 1 have been triaged.
+- [ ] Existing open #22 findings are fixed or explicitly deferred with rationale.
+- [ ] Newly discovered visual findings are listed before implementation.
+- [ ] Newly discovered visual findings are not corrected until approved by the product owner.
+- [ ] Approved small visual findings are fixed inside #22.
+- [ ] Larger or unapproved findings are deferred or converted into follow-up issue recommendations.
+- [ ] The PR includes screenshots or a short recording for the reviewed flow.
+- [ ] Manual verification describes the flow that was tested.
+- [ ] No new product capabilities were added.
+
+## Verification
+
+Automated:
+
+- [ ] Run `pnpm lint`.
+- [ ] Run `pnpm test`.
+- [ ] Run `pnpm build`.
+
+Manual:
+
+- [ ] Open the Phase 1 editor flow end-to-end.
+- [ ] Verify canvas readability, inspector behavior, navigation, interaction feedback, and empty/error states relevant to Phase 1.
+- [ ] Verify toast behavior is consistent across affected actions.
+- [ ] Verify the React Flow attribution text is removed only if licensing and package configuration allow it; otherwise document why it remains.
+- [ ] Verify clicking the empty canvas background clears the active component selection without interfering with nodes, ports, edges, or canvas controls.
+- [ ] Verify creating valid and invalid connections still works.
+- [ ] Verify deleting one connection still preserves other connections.
+- [ ] Verify collapsing and expanding the connections panel still works.
+- [ ] Verify dragging nodes and fit-view/canvas navigation still work.
+- [ ] Verify export, reset, and import still work.
+- [ ] Capture screenshots or a short video/GIF.
+
+## User-reported UX/UI findings
+
+| Date | Finding | Classification | Status | Target |
+| --- | --- | --- | --- | --- |
+| 2026-05-03 | Some UI elements can render outside the visible viewport, making them impossible to see or reach. | UX bug / layout stability | Converted and closed | #33 |
+| 2026-05-03 | Users need a way to delete one chosen existing connection individually. | New graph editing capability | Converted and closed | #26 |
+| 2026-05-04 | Toast notifications should be unified across the Phase 1 editor flow. | Small UX/UI consistency polish | Open in this issue | #22 |
+| 2026-05-04 | Remove the default "React Flow" text shown on the canvas. | Visual polish / product presentation | Open in this issue if licensing and package configuration allow it | #22 |
+| 2026-05-04 | Components should be deselected when clicking the canvas background. | Interaction polish | Open in this issue | #22 |
+| 2026-05-04 | The bottom connections list should be collapsible so it does not take up editor space when it is not needed. | Layout density / workspace efficiency | Converted and closed | #32 |
+| 2026-05-04 | Improve canvas navigation with zoom, pan, and fit-view controls. | Workspace navigation / visibility | Converted and closed | #33 |
+
+## Visual review gate
+
+Before fixing newly discovered visual findings, the agent must present a concise table to the product owner with:
+
+- finding,
+- affected screen or interaction,
+- user impact,
+- recommended decision: fix in #22, defer, or create follow-up issue,
+- implementation risk or scope note.
+
+The product owner must approve each newly discovered finding before it is corrected in this PR.
+
+## Notes
+
+- Design reference: `docs/superpowers/specs/2026-05-05-phase-1-ux-ui-hardening-design.md`.
+- Process reference: `docs/superpowers/specs/2026-05-01-milestone-ux-ui-hardening-design.md`.
+- Related closed follow-up: #33, `[Roadmap]: Phase 1 canvas viewport navigation hardening`.
+- Related closed follow-up: #32, `[Roadmap]: Phase 1 connections panel space management`.
+```
+
+- [ ] **Step 2: Validate the issue body**
+
+Run:
+
+```bash
+pnpm validate:roadmap-issue -- --title "[Roadmap]: Phase 1 UX/UI hardening" --body /tmp/phase-1-ux-ui-hardening-issue.md
+```
+
+Expected: PASS with no missing roadmap sections.
+
+- [ ] **Step 3: Update issue #22**
+
+Run:
+
+```bash
+gh issue edit 22 --repo DoMo-98/dl-graph-studio --body-file /tmp/phase-1-ux-ui-hardening-issue.md
+```
+
+Expected: GitHub updates the issue body.
+
+- [ ] **Step 4: Apply the `ready` label**
+
+Run:
+
+```bash
+gh issue edit 22 --repo DoMo-98/dl-graph-studio --add-label ready
+```
+
+Expected: issue #22 has labels `ux`, `frontend`, and `ready`.
+
+- [ ] **Step 5: Move #22 to Project status `Ready`**
+
+Run:
+
+```bash
+gh project item-list 5 --owner DoMo-98 --format json --limit 100
+```
+
+Then run:
+
+```bash
+gh project item-edit --id PVTI_lAHOA6Chp84BVxUjzgrlIZw --project-id PVT_kwHOA6Chp84BVxUj --field-id PVTSSF_lAHOA6Chp84BVxUjzhRKs98 --single-select-option-id 3888be8f
+```
+
+Expected: issue #22 status in `dl-graph-studio Roadmap` is `Ready`.
+
+- [ ] **Step 6: Confirm the ready contract**
+
+Run:
+
+```bash
+gh issue view 22 --repo DoMo-98/dl-graph-studio --json number,title,labels,projectItems,url
+```
+
+Expected: labels include `ready`; project item status is `Ready`.
+
+---
+
+### Task 2: Create The Implementation Branch And Move #22 To In Progress
+
+**Files:**
+
+- External: Git branch and GitHub Project status
+
+- [ ] **Step 1: Confirm the local checkout is clean and current**
+
+Run:
+
+```bash
+git status --short --branch
+git fetch --prune origin main
+git rev-list --left-right --count HEAD...origin/main
+```
+
+Expected: no local changes; ahead/behind is `0 0`. If the checkout is only behind `origin/main`, run `git merge --ff-only origin/main` and repeat the checks.
+
+- [ ] **Step 2: Create the task branch**
+
+Run:
+
+```bash
+git switch -c codex/22-phase-1-ux-ui-hardening
+```
+
+Expected: branch `codex/22-phase-1-ux-ui-hardening` is active.
+
+- [ ] **Step 3: Move #22 from `Ready` to `In Progress`**
+
+Run:
+
+```bash
+gh project item-list 5 --owner DoMo-98 --format json --limit 100
+```
+
+Then run:
+
+```bash
+gh project item-edit --id PVTI_lAHOA6Chp84BVxUjzgrlIZw --project-id PVT_kwHOA6Chp84BVxUj --field-id PVTSSF_lAHOA6Chp84BVxUjzhRKs98 --single-select-option-id f4184a44
+```
+
+Expected: issue #22 status in `dl-graph-studio Roadmap` is `In Progress`.
+
+- [ ] **Step 4: Confirm branch and issue state**
+
+Run:
+
+```bash
+git status --short --branch
+gh issue view 22 --repo DoMo-98/dl-graph-studio --json projectItems,labels
+```
+
+Expected: on branch `codex/22-phase-1-ux-ui-hardening`, clean worktree, issue #22 has `ready` and Project status `In Progress`.
+
+---
+
+### Task 3: Run The Visual Review Gate Before New Visual Fixes
+
+**Files:**
+
+- Read: `src/App.tsx`
+- Read: `src/styles.css`
+- Output to user: visual findings table
+
+- [ ] **Step 1: Start the app**
+
+Run:
+
+```bash
+pnpm dev
+```
+
+Expected: Vite starts and prints a local URL, usually `http://localhost:5173/`.
+
+- [ ] **Step 2: Inspect the default desktop editor flow**
+
+Open the local app and exercise:
+
+```md
+- default app shell
+- primitive node selection
+- composite node selection
+- inspector parameter editing
+- valid connection creation
+- invalid connection feedback
+- connection deletion
+- connection drawer collapse and expansion
+- node dragging
+- fit-view and zoom controls
+- project export, reset, and import
+```
+
+Expected: each flow works; any visual or interaction issue is recorded, not fixed.
+
+- [ ] **Step 3: Inspect responsive widths**
+
+Repeat a lighter pass at these viewport widths:
+
+```md
+- 1440px wide desktop
+- 1024px narrow desktop/tablet
+- 390px mobile-width viewport
+```
+
+Expected: record visible overlap, unreachable controls, text clipping, broken hierarchy, unclear feedback, or density problems.
+
+- [ ] **Step 4: Present findings and pause**
+
+Send the product owner a table in this exact shape:
+
+```md
+| ID | Finding | Affected screen/interaction | User impact | Recommendation | Risk/scope |
+| --- | --- | --- | --- | --- | --- |
+```
+
+Add one row per newly discovered finding. Use stable IDs in order: `V1`, `V2`, `V3`. If no newly discovered findings are found, send the table header followed by `No newly discovered visual findings.`.
+
+Expected: stop implementation of newly discovered visual findings until the product owner approves specific IDs. Continue only with baseline #22 fixes while waiting if they do not overlap with the unapproved findings.
+
+---
+
+### Task 4: Cover Empty Canvas Click Deselection
+
+**Files:**
+
+- Modify: `src/App.test.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Write the failing interaction test**
+
+In `src/App.test.tsx`, add this test after `selects a composite node and shows basic inspector details`:
+
+```tsx
+it("clears node selection when the empty canvas background is clicked", () => {
+  render(<App />);
+
+  const neuronNode = screen.getByLabelText(/neuron primitive node/i);
+
+  fireEvent.click(neuronNode);
+
+  expect(neuronNode).toHaveAttribute("aria-pressed", "true");
+  expect(
+    within(screen.getByRole("complementary", { name: /node inspector/i }))
+      .getByRole("heading", { name: /neuron/i }),
+  ).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("region", { name: /graph canvas/i }));
+
+  expect(neuronNode).toHaveAttribute("aria-pressed", "false");
+  expect(
+    within(screen.getByRole("complementary", { name: /node inspector/i }))
+      .getByText(/no node selected/i),
+  ).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Write the non-regression test for node clicks**
+
+In `src/App.test.tsx`, add this test immediately after the previous one:
+
+```tsx
+it("does not clear selection when another canvas node is clicked", () => {
+  render(<App />);
+
+  const neuronNode = screen.getByLabelText(/neuron primitive node/i);
+  const activationNode = screen.getByLabelText(/activation primitive node/i);
+
+  fireEvent.click(neuronNode);
+  fireEvent.click(activationNode);
+
+  expect(neuronNode).toHaveAttribute("aria-pressed", "false");
+  expect(activationNode).toHaveAttribute("aria-pressed", "true");
+  expect(
+    within(screen.getByRole("complementary", { name: /node inspector/i }))
+      .getByRole("heading", { name: /activation/i }),
+  ).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 3: Run the focused tests and verify the first one fails**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "clears node selection|does not clear selection"
+```
+
+Expected: the empty-canvas click test fails because the canvas section does not clear `selectedNodeId` yet.
+
+- [ ] **Step 4: Implement minimal canvas background deselection**
+
+In `src/App.tsx`, add this callback near the existing React Flow callbacks:
+
+```tsx
+const clearCanvasSelection = useCallback(() => {
+  setSelectedNodeId(null);
+}, []);
+```
+
+Then add the callback to the existing `<ReactFlow>` props:
+
+```tsx
+onPaneClick={clearCanvasSelection}
+```
+
+If the React Testing Library test clicks the wrapper section and React Flow does not receive pane events in jsdom, add this guarded click handler to `<section className="graph-canvas" aria-label="Graph canvas">` instead:
+
+```tsx
+onClick={(event) => {
+  if (event.target === event.currentTarget) {
+    clearCanvasSelection();
+  }
+}}
+```
+
+Expected behavior: clicks on empty canvas clear selection; clicks inside nodes, ports, edges, controls, and drawers keep their existing handlers.
+
+- [ ] **Step 5: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "clears node selection|does not clear selection"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/App.test.tsx src/App.tsx
+git commit -m "fix: clear canvas selection from empty background"
+```
+
+---
+
+### Task 5: Make React Flow Attribution Handling Explicit
+
+**Files:**
+
+- Modify: `src/App.nodeDrag.test.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Confirm package support and license constraints**
+
+Run:
+
+```bash
+rg -n "attribution|proOptions|hideAttribution" node_modules/@xyflow/react node_modules/@xyflow/system node_modules/@xyflow/core package.json
+```
+
+Expected: confirm whether `proOptions={{ hideAttribution: true }}` is supported and allowed by the installed React Flow package. If no supported option exists, do not implement a hidden workaround; document that attribution remains.
+
+- [ ] **Step 2: Extend the React Flow mock if the supported option exists**
+
+If `proOptions.hideAttribution` is supported, update `MockReactFlowProps` in `src/App.nodeDrag.test.tsx`:
+
+```tsx
+type MockReactFlowProps = {
+  nodes: MockFlowNode[];
+  edges: MockFlowEdge[];
+  nodeTypes: Record<string, ComponentType<{ data: MockFlowNode["data"] }>>;
+  nodesDraggable?: boolean;
+  nodeExtent?: unknown;
+  autoPanOnNodeDrag?: boolean;
+  panOnDrag?: boolean;
+  zoomOnScroll?: boolean;
+  zoomOnPinch?: boolean;
+  zoomOnDoubleClick?: boolean;
+  preventScrolling?: boolean;
+  fitView?: boolean;
+  fitViewOptions?: unknown;
+  minZoom?: number;
+  maxZoom?: number;
+  proOptions?: { hideAttribution?: boolean };
+  onNodesChange?: (
+    changes: Array<{
+      id: string;
+      type: "position";
+      positionAbsolute: { x: number; y: number };
+    }>,
+  ) => void;
+  onConnect?: (connection: { source: string; target: string }) => void;
+  children: ReactNode;
+};
+```
+
+Add `proOptions` to the mocked ReactFlow argument list and expose it:
+
+```tsx
+data-hide-attribution={proOptions?.hideAttribution}
+```
+
+- [ ] **Step 3: Add the failing adapter assertion if the supported option exists**
+
+In the existing viewport adapter test in `src/App.nodeDrag.test.tsx`, add:
+
+```tsx
+expect(reactFlow).toHaveAttribute("data-hide-attribution", "true");
+```
+
+- [ ] **Step 4: Implement the supported option**
+
+In `src/App.tsx`, add this prop to `<ReactFlow>` only if Step 1 confirmed support:
+
+```tsx
+proOptions={{ hideAttribution: true }}
+```
+
+- [ ] **Step 5: Run the focused adapter test**
+
+Run:
+
+```bash
+pnpm test -- src/App.nodeDrag.test.tsx
+```
+
+Expected: PASS if the option is implemented. If the package does not support a permitted attribution removal option, skip code changes for this task and record the reason in the PR verification.
+
+- [ ] **Step 6: Commit if code changed**
+
+```bash
+git add src/App.nodeDrag.test.tsx src/App.tsx
+git commit -m "fix: hide react flow attribution when allowed"
+```
+
+---
+
+### Task 6: Unify Editor Feedback Toast Behavior
+
+**Files:**
+
+- Modify: `src/App.test.tsx`
+- Modify: `src/App.tsx`
+- Modify: `src/styles.css`
+- Optional Modify: `src/useProjectFileWorkflow.ts`
+
+- [ ] **Step 1: Define the unified feedback contract in tests**
+
+In `src/App.test.tsx`, add this test after `rejects duplicate connections with clear feedback`:
+
+```tsx
+it("uses one editor toast surface for connection feedback", () => {
+  render(<App />);
+
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+  const alert = screen.getByRole("alert");
+
+  expect(alert).toHaveClass("editor-toast");
+  expect(alert).toHaveTextContent(/that connection already exists/i);
+  expect(screen.queryByText(/^Project exported\\.$/i)).not.toBeInTheDocument();
+});
+```
+
+Add this test after `deletes one chosen connection while preserving nodes and other connections`:
+
+```tsx
+it("uses the same editor toast surface for connection deletion", () => {
+  render(<App />);
+
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+  fireEvent.click(screen.getByLabelText(/delete connection tensor to neuron/i));
+
+  const alert = screen.getByRole("alert");
+
+  expect(alert).toHaveClass("editor-toast");
+  expect(alert).toHaveTextContent(/tensor -> neuron deleted/i);
+});
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "editor toast surface|connection feedback"
+```
+
+Expected: FAIL because connection feedback currently uses `connection-feedback`, not the unified toast class.
+
+- [ ] **Step 3: Update connection feedback markup**
+
+In `src/App.tsx`, replace the current connection feedback block:
+
+```tsx
+{connectionFeedback ? (
+  <div className="connection-feedback" role="alert">
+    <AlertTriangle size={16} aria-hidden="true" />
+    <span>{connectionFeedback}</span>
+  </div>
+) : null}
+```
+
+with:
+
+```tsx
+{connectionFeedback ? (
+  <div className="editor-toast connection-feedback" role="alert">
+    <AlertTriangle size={16} aria-hidden="true" />
+    <span>{connectionFeedback}</span>
+  </div>
+) : null}
+```
+
+In the project toast block, keep `role="status"` and add the shared class:
+
+```tsx
+{projectToast ? (
+  <div className="editor-toast project-toast" role="status">
+    {projectToast}
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Add shared toast styling without changing placement semantics**
+
+In `src/styles.css`, add or adjust shared toast styles so `.editor-toast` owns common visual treatment and `.project-toast` / `.connection-feedback` keep their existing placement:
+
+```css
+.editor-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink);
+  background: rgb(15 23 42 / 94%);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: var(--shadow-node);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+```
+
+Remove duplicated visual declarations from `.project-toast` and `.connection-feedback` only when `.editor-toast` now supplies them. Keep coordinates, z-index, and max-width declarations on the specific classes.
+
+- [ ] **Step 5: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "editor toast surface|connection feedback"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/App.test.tsx src/App.tsx src/styles.css
+git commit -m "fix: unify editor toast surfaces"
+```
+
+---
+
+### Task 7: Implement Product-Owner-Approved Visual Findings
+
+**Files:**
+
+- Modify only files required by approved findings, usually `src/styles.css`, `src/App.tsx`, or focused tests.
+
+- [ ] **Step 1: Record approved finding IDs**
+
+Create a short local note in the PR draft or working notes with exactly the IDs approved by the product owner:
+
+```md
+Approved for #22:
+
+- V1: use the exact approved finding title from the visual review table
+- V3: use the exact approved finding title from the visual review table
+```
+
+Expected: no unapproved finding is implemented.
+
+- [ ] **Step 2: For each approved finding, write or update a focused test when behavior can regress**
+
+For an approved interaction finding, add a React Testing Library test in `src/App.test.tsx` near related behavior. Example shape:
+
+```tsx
+it("keeps the approved visual or interaction behavior stable", () => {
+  render(<App />);
+
+  fireEvent.click(screen.getByLabelText(/tensor primitive node/i));
+
+  expect(
+    within(screen.getByRole("complementary", { name: /node inspector/i }))
+      .getByRole("heading", { name: /tensor/i }),
+  ).toBeInTheDocument();
+});
+```
+
+Use a real assertion tied to the approved finding. Do not add tests for purely visual color or spacing choices unless the behavior is observable through DOM structure, classes, ARIA, visibility, or text.
+
+- [ ] **Step 3: Apply the smallest approved CSS or markup changes**
+
+For each approved small visual finding, prefer one of these bounded change shapes:
+
+```css
+.topbar-project {
+  min-width: 0;
+}
+```
+
+```css
+.connection-list-item span {
+  overflow-wrap: anywhere;
+}
+```
+
+```tsx
+<button
+  type="button"
+  className="connection-drawer-toggle"
+  aria-label={connectionsPanelToggleLabel}
+  title={connectionsPanelToggleLabel}
+>
+  <ChevronDown size={16} aria-hidden="true" />
+</button>
+```
+
+Expected: changes are small, local, and tied to approved findings.
+
+- [ ] **Step 4: Run focused tests for approved behavior**
+
+Run the focused tests touched for approved findings:
+
+```bash
+pnpm test -- src/App.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit approved findings**
+
+```bash
+git add src/App.test.tsx src/App.tsx src/styles.css
+git commit -m "fix: apply approved phase 1 visual hardening"
+```
+
+If no newly discovered findings are approved, skip this task and document that no additional visual fixes were approved.
+
+---
+
+### Task 8: Full Verification And PR Evidence
+
+**Files:**
+
+- Read/verify: whole app
+- External: screenshots or short recording for PR body
+
+- [ ] **Step 1: Run full automated checks**
+
+Run:
+
+```bash
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Run manual verification**
+
+Start the app:
+
+```bash
+pnpm dev
+```
+
+Verify:
+
+```md
+- Open the Phase 1 editor flow.
+- Select primitive and composite nodes.
+- Edit Tensor shape, Neuron bias, Activation function, and Dense / Linear units.
+- Create a valid Tensor -> Neuron connection.
+- Attempt a duplicate Tensor -> Neuron connection and confirm feedback appears in the unified editor toast style.
+- Attempt Neuron -> Tensor and confirm invalid-connection feedback appears.
+- Delete one connection and confirm remaining connections persist.
+- Collapse and expand the connections panel.
+- Drag at least one primitive node and the composite node.
+- Use pan, zoom, and fit-view controls.
+- Export the current project.
+- Reset the project.
+- Import the exported project and confirm state returns.
+- Select a node, click the empty canvas background, and confirm the inspector returns to "No node selected".
+- Confirm node clicks, port clicks, edge interactions, and canvas controls do not accidentally clear selection.
+- Confirm the React Flow attribution outcome matches the implementation decision.
+```
+
+Expected: each manual step behaves as described.
+
+- [ ] **Step 3: Capture PR evidence**
+
+Capture screenshots or a short recording showing:
+
+```md
+- default editor surface,
+- selected node and inspector,
+- connection feedback toast,
+- collapsed and expanded connection drawer,
+- canvas controls/fit-view,
+- no node selected after empty canvas click.
+```
+
+Expected: evidence is ready to attach or link in the PR description.
+
+- [ ] **Step 4: Update Project status and open PR**
+
+Push the branch:
+
+```bash
+git push -u origin codex/22-phase-1-ux-ui-hardening
+```
+
+Open a draft PR that includes:
+
+```md
+Closes #22
+
+## Summary
+
+- Fixed baseline Phase 1 hardening findings from #22.
+- Applied only product-owner-approved visual review findings, or state that no newly discovered findings were approved.
+- Documented deferred findings and follow-up recommendations where applicable.
+
+## Verification
+
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] `pnpm build`
+- [ ] Manual Phase 1 flow verified
+- [ ] Screenshots or recording attached
+
+## Visual review gate
+
+| ID | Finding | Decision |
+| --- | --- | --- |
+```
+
+Add one row per visual review finding using the same IDs from Task 3.
+
+Expected: PR links #22 with `Closes #22`; issue #22 Project status moves to `In Review`.
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: Tasks cover issue readiness, visual review gate, pre-approved #22 fixes, product-owner approval for new findings, follow-up recommendations, automated checks, manual verification, and PR evidence.
+- Placeholder scan: no `TBD`, `TODO`, `FIXME`, or unresolved placeholders are present. Runtime-specific visual finding rows are intentionally generated during Task 3 after inspecting the app.
+- Type consistency: planned React changes use existing state names (`selectedNodeId`, `connectionFeedback`, `projectToast`), existing test files, existing React Flow props, and existing CSS classes.
+- Scope check: the plan excludes new capabilities, broad redesign, dependencies, persistence changes, and unapproved visual fixes.

--- a/docs/superpowers/plans/2026-05-08-editor-toast-unification.md
+++ b/docs/superpowers/plans/2026-05-08-editor-toast-unification.md
@@ -1,0 +1,636 @@
+# Editor Toast Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace split project and connection feedback with one editor toast system that has consistent placement, lifecycle, ARIA semantics, and icon treatment.
+
+**Architecture:** Add a small local `useEditorToast` hook that owns the active toast and severity-based timeout. `App.tsx` remains the composition boundary: project file workflow emits toast requests through a callback, and connection actions use the same callback. One JSX toast surface renders the active toast.
+
+**Tech Stack:** React, TypeScript, Vitest, React Testing Library, lucide-react, CSS.
+
+---
+
+## File Structure
+
+- Create `src/useEditorToast.ts`: owns toast state, severity-based timeout, `showToast`, and `clearToast`.
+- Create `src/useEditorToast.test.tsx`: focused hook tests for replacement and timeout behavior.
+- Modify `src/useProjectFileWorkflow.ts`: remove local `projectToast` state and emit project feedback through `showToast`.
+- Modify `src/useProjectFileWorkflow.test.tsx`: update harness to assert emitted toast requests instead of hook-owned toast state.
+- Modify `src/App.tsx`: use `useEditorToast`, replace `connectionFeedback`, render one editor toast surface, and choose severity/icons per message.
+- Modify `src/App.test.tsx`: update app-level assertions for one toast surface, severity roles, icon behavior, and replacement behavior.
+- Modify `src/styles.css`: keep `.editor-toast` as the shared surface, move shared placement onto it, remove separate placement classes, and add tone classes.
+
+---
+
+### Task 1: Add the Editor Toast Hook
+
+**Files:**
+- Create: `src/useEditorToast.ts`
+- Create: `src/useEditorToast.test.tsx`
+
+- [ ] **Step 1: Write failing hook tests**
+
+Create `src/useEditorToast.test.tsx`:
+
+```tsx
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useEditorToast } from "./useEditorToast";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useEditorToast", () => {
+  it("shows one toast and replaces the previous toast", () => {
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({ message: "Project exported.", tone: "success" });
+    });
+
+    expect(result.current.toast).toEqual({
+      message: "Project exported.",
+      tone: "success",
+    });
+
+    act(() => {
+      result.current.showToast({
+        message: "That connection already exists.",
+        tone: "error",
+      });
+    });
+
+    expect(result.current.toast).toEqual({
+      message: "That connection already exists.",
+      tone: "error",
+    });
+  });
+
+  it("clears success and info toasts after three seconds", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({ message: "Project reset.", tone: "success" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2999);
+    });
+
+    expect(result.current.toast?.message).toBe("Project reset.");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.toast).toBeNull();
+
+    act(() => {
+      result.current.showToast({ message: "Ready.", tone: "info" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.toast).toBeNull();
+  });
+
+  it("keeps error toasts visible for five seconds", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({
+        message: "Project file could not be read.",
+        tone: "error",
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+
+    expect(result.current.toast?.message).toBe(
+      "Project file could not be read.",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.toast).toBeNull();
+  });
+
+  it("clears the active toast on demand", () => {
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({ message: "Project imported.", tone: "success" });
+    });
+    act(() => {
+      result.current.clearToast();
+    });
+
+    expect(result.current.toast).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm test -- src/useEditorToast.test.tsx
+```
+
+Expected: FAIL because `src/useEditorToast.ts` does not exist.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/useEditorToast.ts`:
+
+```ts
+import { useCallback, useEffect, useState } from "react";
+
+export type EditorToastTone = "success" | "info" | "error";
+
+export type EditorToast = {
+  message: string;
+  tone: EditorToastTone;
+};
+
+const editorToastDurations: Record<EditorToastTone, number> = {
+  success: 3000,
+  info: 3000,
+  error: 5000,
+};
+
+export function useEditorToast() {
+  const [toast, setToast] = useState<EditorToast | null>(null);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setToast(null);
+    }, editorToastDurations[toast.tone]);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [toast]);
+
+  const showToast = useCallback((nextToast: EditorToast) => {
+    setToast(nextToast);
+  }, []);
+
+  const clearToast = useCallback(() => {
+    setToast(null);
+  }, []);
+
+  return {
+    toast,
+    showToast,
+    clearToast,
+  };
+}
+```
+
+- [ ] **Step 4: Run hook tests**
+
+Run:
+
+```bash
+pnpm test -- src/useEditorToast.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add src/useEditorToast.ts src/useEditorToast.test.tsx
+git commit -m "test: add editor toast lifecycle hook"
+```
+
+---
+
+### Task 2: Move Project Workflow Toasts Onto the Shared API
+
+**Files:**
+- Modify: `src/useProjectFileWorkflow.ts`
+- Modify: `src/useProjectFileWorkflow.test.tsx`
+
+- [ ] **Step 1: Write failing project workflow expectations**
+
+In `src/useProjectFileWorkflow.test.tsx`, import the toast type and replace the harness-owned toast output.
+
+Add imports:
+
+```tsx
+import type { EditorToast } from "./useEditorToast";
+```
+
+Inside `WorkflowHarness`, replace the local connection feedback state with emitted toast state:
+
+```tsx
+const [lastToast, setLastToast] = useState<EditorToast | null>(null);
+```
+
+Pass `showToast` into `useProjectFileWorkflow`:
+
+```tsx
+showToast: setLastToast,
+```
+
+Replace the toast output with:
+
+```tsx
+<output aria-label="toast">
+  {lastToast ? `${lastToast.tone}: ${lastToast.message}` : "none"}
+</output>
+```
+
+Update assertions:
+
+```tsx
+expect(screen.getByLabelText("toast")).toHaveTextContent(
+  "success: Project exported.",
+);
+expect(screen.getByLabelText("toast")).toHaveTextContent(
+  "success: Project imported.",
+);
+expect(screen.getByLabelText("toast")).toHaveTextContent(
+  "success: Project reset.",
+);
+expect(screen.getByLabelText("toast")).toHaveTextContent(
+  "error: Project file could not be read.",
+);
+```
+
+For parse failures, assert:
+
+```tsx
+expect(screen.getByLabelText("toast")).toHaveTextContent(/^error: /);
+```
+
+Delete the test named `clears project toasts after three seconds`; timeout behavior now belongs to `useEditorToast.test.tsx`.
+
+- [ ] **Step 2: Run project workflow tests to verify failure**
+
+Run:
+
+```bash
+pnpm test -- src/useProjectFileWorkflow.test.tsx
+```
+
+Expected: FAIL because `useProjectFileWorkflow` does not accept `showToast` and still returns `projectToast`.
+
+- [ ] **Step 3: Update the project workflow hook**
+
+In `src/useProjectFileWorkflow.ts`, add the import:
+
+```ts
+import type { EditorToast } from "./useEditorToast";
+```
+
+Add the option:
+
+```ts
+showToast: (toast: EditorToast) => void;
+```
+
+Remove:
+
+```ts
+useEffect,
+const [projectToast, setProjectToast] = useState<string | null>(null);
+```
+
+Replace project toast writes:
+
+```ts
+showToast({ message: "Project exported.", tone: "success" });
+showToast({ message: "Project file could not be read.", tone: "error" });
+showToast({ message: parsedProject.message, tone: "error" });
+showToast({ message: "Project imported.", tone: "success" });
+showToast({ message: "Project reset.", tone: "success" });
+```
+
+Remove `projectToast` from the return value.
+
+- [ ] **Step 4: Run project workflow tests**
+
+Run:
+
+```bash
+pnpm test -- src/useProjectFileWorkflow.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add src/useProjectFileWorkflow.ts src/useProjectFileWorkflow.test.tsx
+git commit -m "refactor: route project feedback through editor toasts"
+```
+
+---
+
+### Task 3: Render One Toast Surface in the Editor
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/App.test.tsx`
+- Modify: `src/styles.css`
+
+- [ ] **Step 1: Write failing app-level tests**
+
+In `src/App.test.tsx`, add tests in `describe("App shell", ...)` near existing toast assertions:
+
+```tsx
+it("renders project feedback through the editor toast surface", () => {
+  const createObjectUrl = vi.fn(() => "blob:project");
+  const revokeObjectUrl = vi.fn();
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: createObjectUrl,
+    revokeObjectURL: revokeObjectUrl,
+  });
+
+  render(<App />);
+
+  fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+  fireEvent.click(screen.getByRole("menuitem", { name: /export project/i }));
+
+  const toast = screen.getByRole("status");
+
+  expect(toast).toHaveClass("editor-toast");
+  expect(toast).toHaveClass("success");
+  expect(toast).toHaveTextContent("Project exported.");
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+it("renders invalid connection feedback as one error toast", () => {
+  render(<App />);
+
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+  const toast = screen.getByRole("alert");
+
+  expect(toast).toHaveClass("editor-toast");
+  expect(toast).toHaveClass("error");
+  expect(toast).toHaveTextContent("That connection already exists.");
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});
+
+it("uses success treatment for connection deletion feedback", () => {
+  render(<App />);
+
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+  fireEvent.click(screen.getByLabelText(/delete connection tensor to neuron/i));
+
+  const toast = screen.getByRole("status");
+
+  expect(toast).toHaveClass("editor-toast");
+  expect(toast).toHaveClass("success");
+  expect(toast).toHaveTextContent("Tensor -> Neuron deleted.");
+  expect(within(toast).queryByTestId("toast-error-icon")).not.toBeInTheDocument();
+});
+```
+
+Update existing tests that use `screen.getByRole("alert")` for deletion success to `screen.getByRole("status")`.
+
+- [ ] **Step 2: Run app tests to verify failure**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "toast|connection feedback|connection deletion"
+```
+
+Expected: FAIL because `App` still renders separate `projectToast` and `connectionFeedback` surfaces.
+
+- [ ] **Step 3: Update `App.tsx` to use the shared hook**
+
+Add imports:
+
+```tsx
+import { CheckCircle2, InfoIcon, AlertTriangle } from "lucide-react";
+import { useEditorToast } from "./useEditorToast";
+import type { EditorToast } from "./useEditorToast";
+```
+
+Remove the `connectionFeedback` state. Add:
+
+```tsx
+const { toast, showToast, clearToast } = useEditorToast();
+```
+
+Pass `showToast` and `clearToast` into `useProjectFileWorkflow`:
+
+```tsx
+showToast,
+clearConnectionFeedback: clearToast,
+```
+
+Replace invalid connection feedback:
+
+```tsx
+showToast({ message: validation.message, tone: "error" });
+```
+
+Replace valid connection cleanup:
+
+```tsx
+clearToast();
+```
+
+Replace deletion feedback:
+
+```tsx
+showToast({ message: `${connectionLabel} deleted.`, tone: "success" });
+```
+
+Add a local icon helper above `return`:
+
+```tsx
+const toastIconByTone: Record<EditorToast["tone"], JSX.Element> = {
+  success: <CheckCircle2 size={16} aria-hidden="true" />,
+  info: <InfoIcon size={16} aria-hidden="true" />,
+  error: (
+    <AlertTriangle
+      size={16}
+      aria-hidden="true"
+      data-testid="toast-error-icon"
+    />
+  ),
+};
+```
+
+Remove the separate project toast JSX and replace connection feedback JSX with one surface:
+
+```tsx
+{toast ? (
+  <div
+    className={`editor-toast ${toast.tone}`}
+    role={toast.tone === "error" ? "alert" : "status"}
+  >
+    {toastIconByTone[toast.tone]}
+    <span>{toast.message}</span>
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Update styles**
+
+In `src/styles.css`, keep `.editor-toast` and move placement into it:
+
+```css
+.editor-toast {
+  position: fixed;
+  left: 50%;
+  top: 60px;
+  z-index: 60;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(420px, calc(100vw - 36px));
+  padding: 10px 12px;
+  color: var(--ink);
+  background: rgb(15 23 42 / 94%);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: var(--shadow-node);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.3;
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+
+.editor-toast.success {
+  border-color: rgb(20 184 166 / 35%);
+}
+
+.editor-toast.info {
+  border-color: rgb(59 130 246 / 35%);
+}
+
+.editor-toast.error {
+  border-color: rgb(239 68 68 / 45%);
+}
+
+.editor-toast svg {
+  flex: 0 0 auto;
+}
+```
+
+Remove `.project-toast`, `.connection-feedback`, and `.connection-feedback svg`.
+
+- [ ] **Step 5: Run app tests**
+
+Run:
+
+```bash
+pnpm test -- src/App.test.tsx -t "toast|connection feedback|connection deletion"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add src/App.tsx src/App.test.tsx src/styles.css
+git commit -m "feat: render unified editor toast surface"
+```
+
+---
+
+### Task 4: Full Verification
+
+**Files:**
+- Modify if needed: only files touched in Tasks 1-3.
+
+- [ ] **Step 1: Run focused toast tests**
+
+Run:
+
+```bash
+pnpm test -- src/useEditorToast.test.tsx src/useProjectFileWorkflow.test.tsx src/App.test.tsx -t "toast|connection feedback|connection deletion|project"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```bash
+pnpm lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run build**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual verification checklist**
+
+Start the app:
+
+```bash
+pnpm dev
+```
+
+Verify:
+
+- Export project shows one success toast at the shared top-center placement and clears after about 3 seconds.
+- Reset project shows one success toast at the same placement and clears after about 3 seconds.
+- Importing invalid JSON shows one error toast at the same placement and clears after about 5 seconds.
+- Creating a duplicate connection shows one error toast and replaces any previous project toast.
+- Deleting a connection shows one success toast with success icon treatment, not warning imagery.
+
+- [ ] **Step 6: Commit verification fixes if any**
+
+If verification requires small fixes, commit only those fixes:
+
+```bash
+git add src/useEditorToast.ts src/useEditorToast.test.tsx src/useProjectFileWorkflow.ts src/useProjectFileWorkflow.test.tsx src/App.tsx src/App.test.tsx src/styles.css
+git commit -m "fix: polish unified editor toast behavior"
+```

--- a/docs/superpowers/specs/2026-05-05-phase-1-ux-ui-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-05-phase-1-ux-ui-hardening-design.md
@@ -80,6 +80,28 @@ Any fix that requires substantial state-model changes, new graph behavior,
 new controls, new persistent data, or a large layout rewrite should be excluded
 from #22 and proposed as follow-up roadmap work.
 
+## Toast Notification Design
+
+Toast notifications should use one editor-level notification system instead of
+separate project and connection feedback state with different lifecycles. The
+system should remain local to the Phase 1 editor; it does not need a global app
+provider or a third-party toast dependency.
+
+The editor should show one toast at a time. A new toast replaces the previous
+toast so import/export/reset feedback, connection validation feedback, and
+connection deletion feedback do not compete for attention in separate surfaces.
+
+Toasts should share one visual surface and one placement. Message behavior may
+vary only by severity:
+
+- `success` and `info` toasts use `role="status"` and auto-clear after 3000
+  milliseconds.
+- `error` toasts use `role="alert"` and auto-clear after 5000 milliseconds so
+  users have more time to read corrective feedback.
+
+Icons should match severity. Success feedback should not use warning imagery,
+and warning/error imagery should be reserved for invalid or failed actions.
+
 ## Verification
 
 Automated verification should run:

--- a/docs/superpowers/specs/2026-05-05-phase-1-ux-ui-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-05-phase-1-ux-ui-hardening-design.md
@@ -1,0 +1,120 @@
+# Phase 1 UX/UI Hardening Design
+
+## Context
+
+Issue #22 is the final Phase 1 UX/UI closeout pass for `dl-graph-studio`.
+The Phase 1 implementation now includes the core architecture editor flow:
+primitive and composite nodes, selection, inspector details, parameter editing,
+connections, validation feedback, import/export/reset, node movement, a
+collapsible connections panel, and canvas viewport navigation controls.
+
+The hardening pass should tighten that delivered experience without becoming a
+redesign bucket or a place to add new product capabilities. It should also keep
+product-owner control over subjective visual polish.
+
+## Goal
+
+Review the complete Phase 1 editor experience, fix the already-approved small
+UX/UI findings in issue #22, and produce a product-owner-approved list before
+fixing any newly discovered visual or interaction details.
+
+## Scope
+
+The issue should include:
+
+- An end-to-end visual review of the primary Phase 1 editor flow.
+- Triage of all product-owner-reported UX/UI findings listed in issue #22.
+- Implementation of the existing open #22 findings:
+  - unify toast notifications across the Phase 1 editor flow,
+  - remove the default React Flow attribution only if licensing and package
+    configuration allow it,
+  - clear the active component selection when clicking the empty canvas
+    background without interfering with nodes, ports, edges, or controls.
+- A visual findings list for small newly discovered issues, with each finding
+  classified before implementation.
+- Product-owner approval before correcting any newly discovered finding.
+- Follow-up roadmap issue drafts or issue recommendations for findings that are
+  too large, subjective, or capability-like for #22.
+- Screenshots or a short recording for the reviewed flow.
+
+## Out Of Scope
+
+The issue must not include:
+
+- New product capabilities.
+- Large redesigns or broad layout rethinks.
+- Broad refactors unrelated to the UX/UI hardening pass.
+- Dependency changes unless required for a scoped hardening fix.
+- Changes to future milestone behavior.
+- Reopening completed follow-up work from #26, #32, or #33.
+- Fixing newly discovered visual findings before product-owner approval.
+
+## Visual Review Gate
+
+The implementation should start with a visual review pass before making
+subjective visual corrections. The agent should inspect the running app across
+the primary Phase 1 flow and produce a concise table with:
+
+- finding,
+- affected screen or interaction,
+- user impact,
+- recommended decision: fix in #22, defer, or create follow-up issue,
+- implementation risk or scope note.
+
+The existing open findings in #22 are pre-approved for implementation because
+they are already part of the issue contract. Newly discovered findings are not
+pre-approved. The agent must present the table to the product owner and wait
+for approval before fixing any of them.
+
+If the product owner approves only some findings, #22 should fix only those.
+Unapproved findings should be documented as deferred or converted into
+follow-up issue recommendations.
+
+## Implementation Boundaries
+
+The implementation should stay close to the existing app structure and visual
+system. Changes should favor small CSS adjustments, small interaction fixes, or
+focused component behavior changes over broad decomposition.
+
+Any fix that requires substantial state-model changes, new graph behavior,
+new controls, new persistent data, or a large layout rewrite should be excluded
+from #22 and proposed as follow-up roadmap work.
+
+## Verification
+
+Automated verification should run:
+
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+
+Manual verification should cover:
+
+- opening the primary Phase 1 editor flow,
+- selecting primitive and composite nodes,
+- editing supported parameters,
+- creating valid and invalid connections,
+- deleting an individual connection,
+- collapsing and expanding the connections panel,
+- dragging nodes and using fit-view/canvas navigation,
+- exporting, resetting, and importing a project,
+- confirming toast behavior is consistent,
+- confirming background canvas clicks clear active component selection without
+  disrupting nodes, ports, edges, or controls,
+- confirming the React Flow attribution outcome is documented,
+- capturing screenshots or a short recording of the final reviewed flow.
+
+## Acceptance Criteria
+
+- The primary Phase 1 flow has been reviewed end-to-end.
+- Product-owner-reported UX/UI findings in #22 have been triaged.
+- Existing open #22 findings are fixed or explicitly deferred with rationale.
+- Newly discovered findings are listed and not corrected until approved by the
+  product owner.
+- Approved small visual findings are fixed inside #22.
+- Larger or unapproved findings are deferred or converted into follow-up issue
+  recommendations.
+- Automated verification passes or any skipped check is explained.
+- Manual verification documents the reviewed flow.
+- The pull request includes screenshots or a short recording.
+- No new product capabilities are added.

--- a/src/App.nodeDrag.test.tsx
+++ b/src/App.nodeDrag.test.tsx
@@ -37,6 +37,9 @@ type MockReactFlowProps = {
   preventScrolling?: boolean;
   fitView?: boolean;
   fitViewOptions?: unknown;
+  proOptions?: {
+    hideAttribution?: boolean;
+  };
   minZoom?: number;
   maxZoom?: number;
   onNodesChange?: (
@@ -79,6 +82,7 @@ vi.mock("@xyflow/react", () => ({
     preventScrolling,
     fitView,
     fitViewOptions,
+    proOptions,
     minZoom,
     maxZoom,
     onNodesChange,
@@ -103,6 +107,7 @@ vi.mock("@xyflow/react", () => ({
         data-prevent-scrolling={preventScrolling}
         data-fit-view={fitView}
         data-fit-view-options={JSON.stringify(fitViewOptions)}
+        data-pro-options={JSON.stringify(proOptions)}
         data-min-zoom={minZoom}
         data-max-zoom={maxZoom}
       >
@@ -232,6 +237,10 @@ describe("App node dragging", () => {
     expect(reactFlow).toHaveAttribute(
       "data-fit-view-options",
       JSON.stringify({ padding: 0.18 }),
+    );
+    expect(reactFlow).toHaveAttribute(
+      "data-pro-options",
+      JSON.stringify({ hideAttribution: true }),
     );
     expect(screen.getByTestId("flow-controls")).toHaveAttribute(
       "data-fit-view-options",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -440,6 +440,19 @@ describe("App shell", () => {
     expect(screen.getByLabelText(/neuron primitive node/i)).toBeInTheDocument();
   });
 
+  it("uses the same editor toast surface for connection deletion", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+    fireEvent.click(screen.getByLabelText(/delete connection tensor to neuron/i));
+
+    const alert = screen.getByRole("alert");
+
+    expect(alert).toHaveClass("editor-toast");
+    expect(alert).toHaveTextContent(/tensor -> neuron deleted/i);
+  });
+
   it("rejects duplicate connections with clear feedback", () => {
     render(<App />);
 
@@ -456,6 +469,21 @@ describe("App shell", () => {
     expect(
       screen.getByText(/that connection already exists/i),
     ).toBeInTheDocument();
+  });
+
+  it("uses one editor toast surface for connection feedback", () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+    fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+    fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
+
+    const alert = screen.getByRole("alert");
+
+    expect(alert).toHaveClass("editor-toast");
+    expect(alert).toHaveTextContent(/that connection already exists/i);
+    expect(screen.queryByText(/^Project exported\.$/i)).not.toBeInTheDocument();
   });
 
   it("rejects connections into the tensor input node with clear feedback", () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -82,6 +82,21 @@ describe("App shell", () => {
     ).toBeInTheDocument();
   });
 
+  it("groups the project title and ready status for narrow topbar wrapping", () => {
+    render(<App />);
+
+    const projectStatusGroup = screen
+      .getByText("Ready")
+      .closest(".topbar-project-status");
+
+    expect(projectStatusGroup).not.toBeNull();
+    expect(
+      within(projectStatusGroup as HTMLElement).getByLabelText(
+        /current project/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("renders deterministic primitive architecture nodes on the canvas", () => {
     render(<App />);
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -208,6 +208,45 @@ describe("App shell", () => {
     ).toBeInTheDocument();
   });
 
+  it("clears node selection when the empty canvas background is clicked", () => {
+    render(<App />);
+
+    const neuronNode = screen.getByLabelText(/neuron primitive node/i);
+
+    fireEvent.click(neuronNode);
+
+    expect(neuronNode).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(screen.getByRole("complementary", { name: /node inspector/i }))
+        .getByRole("heading", { name: /neuron/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("region", { name: /graph canvas/i }));
+
+    expect(neuronNode).toHaveAttribute("aria-pressed", "false");
+    expect(
+      within(screen.getByRole("complementary", { name: /node inspector/i }))
+        .getByText(/no node selected/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not clear selection when another canvas node is clicked", () => {
+    render(<App />);
+
+    const neuronNode = screen.getByLabelText(/neuron primitive node/i);
+    const activationNode = screen.getByLabelText(/activation primitive node/i);
+
+    fireEvent.click(neuronNode);
+    fireEvent.click(activationNode);
+
+    expect(neuronNode).toHaveAttribute("aria-pressed", "false");
+    expect(activationNode).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(screen.getByRole("complementary", { name: /node inspector/i }))
+        .getByRole("heading", { name: /activation/i }),
+    ).toBeInTheDocument();
+  });
+
   it("updates selected node parameters and keeps values associated with each node", () => {
     render(<App />);
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -100,6 +100,9 @@ describe("App shell", () => {
   it("renders project feedback through the editor toast surface", () => {
     const createObjectUrl = vi.fn(() => "blob:project");
     const revokeObjectUrl = vi.fn();
+    const anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
     vi.stubGlobal("URL", {
       ...URL,
       createObjectURL: createObjectUrl,
@@ -116,6 +119,9 @@ describe("App shell", () => {
     expect(toast).toHaveClass("editor-toast");
     expect(toast).toHaveClass("success");
     expect(toast).toHaveTextContent("Project exported.");
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+    expect(anchorClick).toHaveBeenCalledTimes(1);
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:project");
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
@@ -254,16 +260,18 @@ describe("App shell", () => {
 
     expect(neuronNode).toHaveAttribute("aria-pressed", "true");
     expect(
-      within(screen.getByRole("complementary", { name: /node inspector/i }))
-        .getByRole("heading", { name: /neuron/i }),
+      within(
+        screen.getByRole("complementary", { name: /node inspector/i }),
+      ).getByRole("heading", { name: /neuron/i }),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("region", { name: /graph canvas/i }));
 
     expect(neuronNode).toHaveAttribute("aria-pressed", "false");
     expect(
-      within(screen.getByRole("complementary", { name: /node inspector/i }))
-        .getByText(/no node selected/i),
+      within(
+        screen.getByRole("complementary", { name: /node inspector/i }),
+      ).getByText(/no node selected/i),
     ).toBeInTheDocument();
   });
 
@@ -279,8 +287,9 @@ describe("App shell", () => {
     expect(neuronNode).toHaveAttribute("aria-pressed", "false");
     expect(activationNode).toHaveAttribute("aria-pressed", "true");
     expect(
-      within(screen.getByRole("complementary", { name: /node inspector/i }))
-        .getByRole("heading", { name: /activation/i }),
+      within(
+        screen.getByRole("complementary", { name: /node inspector/i }),
+      ).getByRole("heading", { name: /activation/i }),
     ).toBeInTheDocument();
   });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -97,6 +97,28 @@ describe("App shell", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders project feedback through the editor toast surface", () => {
+    const createObjectUrl = vi.fn(() => "blob:project");
+    const revokeObjectUrl = vi.fn();
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: createObjectUrl,
+      revokeObjectURL: revokeObjectUrl,
+    });
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /export project/i }));
+
+    const toast = screen.getByRole("status");
+
+    expect(toast).toHaveClass("editor-toast");
+    expect(toast).toHaveClass("success");
+    expect(toast).toHaveTextContent("Project exported.");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("renders deterministic primitive architecture nodes on the canvas", () => {
     render(<App />);
 
@@ -448,24 +470,30 @@ describe("App shell", () => {
     expect(
       within(connectionList).getByText("Neuron -> Activation"),
     ).toBeInTheDocument();
-    expect(screen.getByRole("alert")).toHaveTextContent(
+    expect(screen.getByRole("status")).toHaveTextContent(
       /tensor -> neuron deleted/i,
     );
     expect(screen.getByLabelText(/tensor primitive node/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/neuron primitive node/i)).toBeInTheDocument();
   });
 
-  it("uses the same editor toast surface for connection deletion", () => {
+  it("uses success treatment for connection deletion feedback", () => {
     render(<App />);
 
     fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
     fireEvent.click(screen.getByLabelText(/connect tensor to neuron/i));
-    fireEvent.click(screen.getByLabelText(/delete connection tensor to neuron/i));
+    fireEvent.click(
+      screen.getByLabelText(/delete connection tensor to neuron/i),
+    );
 
-    const alert = screen.getByRole("alert");
+    const toast = screen.getByRole("status");
 
-    expect(alert).toHaveClass("editor-toast");
-    expect(alert).toHaveTextContent(/tensor -> neuron deleted/i);
+    expect(toast).toHaveClass("editor-toast");
+    expect(toast).toHaveClass("success");
+    expect(toast).toHaveTextContent("Tensor -> Neuron deleted.");
+    expect(
+      within(toast).queryByTestId("toast-error-icon"),
+    ).not.toBeInTheDocument();
   });
 
   it("rejects duplicate connections with clear feedback", () => {
@@ -486,7 +514,7 @@ describe("App shell", () => {
     ).toBeInTheDocument();
   });
 
-  it("uses one editor toast surface for connection feedback", () => {
+  it("renders invalid connection feedback as one error toast", () => {
     render(<App />);
 
     fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
@@ -497,8 +525,9 @@ describe("App shell", () => {
     const alert = screen.getByRole("alert");
 
     expect(alert).toHaveClass("editor-toast");
-    expect(alert).toHaveTextContent(/that connection already exists/i);
-    expect(screen.queryByText(/^Project exported\.$/i)).not.toBeInTheDocument();
+    expect(alert).toHaveClass("error");
+    expect(alert).toHaveTextContent("That connection already exists.");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
   it("rejects connections into the tensor input node with clear feedback", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,14 @@ import {
   AlertTriangle,
   BookOpen,
   Box,
+  CheckCircle2,
   ChevronDown,
   ChevronsRight,
   CircuitBoard,
   Grid,
   Hand,
   Info,
+  InfoIcon,
   Link2,
   MousePointer2,
   Play,
@@ -29,6 +31,7 @@ import {
   useMemo,
   useState,
   type ChangeEvent,
+  type JSX,
   type KeyboardEvent,
 } from "react";
 import {
@@ -47,6 +50,7 @@ import {
 
 import "@xyflow/react/dist/style.css";
 import { updateGraphNodePositions } from "./projectFile";
+import { useEditorToast } from "./useEditorToast";
 import type {
   CompositeNode,
   GraphNode,
@@ -56,6 +60,7 @@ import type {
   PrimitiveNodeParameter,
 } from "./projectFile";
 import { useProjectFileWorkflow } from "./useProjectFileWorkflow";
+import type { EditorToast } from "./useEditorToast";
 
 type ConnectionValidationResult =
   | { isValid: true }
@@ -435,9 +440,7 @@ export function App() {
   const [graphConnections, setGraphConnections] = useState<GraphConnection[]>(
     [],
   );
-  const [connectionFeedback, setConnectionFeedback] = useState<string | null>(
-    null,
-  );
+  const { toast, showToast, clearToast } = useEditorToast();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null);
   const [connectionSourceId, setConnectionSourceId] = useState<string | null>(
@@ -448,7 +451,6 @@ export function App() {
   const {
     isProjectActionsOpen,
     setIsProjectActionsOpen,
-    projectToast,
     fileInputRef,
     openProjectImportPicker,
     exportProjectFile,
@@ -462,8 +464,9 @@ export function App() {
     createInitialGraphNodes,
     clearSelectedNode: () => setSelectedNodeId(null),
     clearConnectionSource: () => setConnectionSourceId(null),
-    clearConnectionFeedback: () => setConnectionFeedback(null),
+    clearConnectionFeedback: clearToast,
     clearDraggedNode: () => setDraggedNodeId(null),
+    showToast,
   });
   const selectedNode =
     graphNodes.find((node) => node.id === selectedNodeId) ?? null;
@@ -503,7 +506,7 @@ export function App() {
       );
 
       if (!validation.isValid) {
-        setConnectionFeedback(validation.message);
+        showToast({ message: validation.message, tone: "error" });
         setConnectionSourceId(null);
         return;
       }
@@ -516,10 +519,10 @@ export function App() {
           target: targetId,
         },
       ]);
-      setConnectionFeedback(null);
+      clearToast();
       setConnectionSourceId(null);
     },
-    [graphConnections, graphNodes],
+    [clearToast, graphConnections, graphNodes, showToast],
   );
 
   const completeGraphConnection = useCallback(
@@ -620,9 +623,9 @@ export function App() {
         ),
       );
       setConnectionSourceId(null);
-      setConnectionFeedback(`${connectionLabel} deleted.`);
+      showToast({ message: `${connectionLabel} deleted.`, tone: "success" });
     },
-    [graphConnections, graphNodes],
+    [graphConnections, graphNodes, showToast],
   );
 
   const canvasNodes: GraphFlowNode[] = useMemo(
@@ -738,6 +741,18 @@ export function App() {
   const connectionsPanelToggleLabel = isConnectionsPanelCollapsed
     ? "Expand connections panel"
     : "Collapse connections panel";
+
+  const toastIconByTone: Record<EditorToast["tone"], JSX.Element> = {
+    success: <CheckCircle2 size={16} aria-hidden="true" />,
+    info: <InfoIcon size={16} aria-hidden="true" />,
+    error: (
+      <AlertTriangle
+        size={16}
+        aria-hidden="true"
+        data-testid="toast-error-icon"
+      />
+    ),
+  };
 
   return (
     <div className="app-shell">
@@ -870,9 +885,13 @@ export function App() {
         </div>
       </header>
 
-      {projectToast ? (
-        <div className="editor-toast project-toast" role="status">
-          {projectToast}
+      {toast ? (
+        <div
+          className={`editor-toast ${toast.tone}`}
+          role={toast.tone === "error" ? "alert" : "status"}
+        >
+          {toastIconByTone[toast.tone]}
+          <span>{toast.message}</span>
         </div>
       ) : null}
 
@@ -1025,13 +1044,6 @@ export function App() {
                 </div>
               ) : null}
             </section>
-          ) : null}
-
-          {connectionFeedback ? (
-            <div className="editor-toast connection-feedback" role="alert">
-              <AlertTriangle size={16} aria-hidden="true" />
-              <span>{connectionFeedback}</span>
-            </div>
           ) : null}
         </section>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -952,6 +952,7 @@ export function App() {
               preventScrolling={true}
               fitView={true}
               fitViewOptions={{ padding: 0.18 }}
+              proOptions={{ hideAttribution: true }}
               minZoom={0.6}
               maxZoom={1.5}
             >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -742,7 +742,7 @@ export function App() {
   return (
     <div className="app-shell">
       <header className="app-topbar">
-        <div style={{ display: "flex", gap: "24px", alignItems: "center" }}>
+        <div className="topbar-project-status">
           <div className="brand-lockup">
             <div className="brand-mark" aria-hidden="true">
               <CircuitBoard size={18} strokeWidth={2} />
@@ -904,9 +904,8 @@ export function App() {
           </nav>
 
           <nav
-            className="nav-list"
+            className="nav-list utility-nav-list"
             aria-label="Utility actions"
-            style={{ marginTop: "auto" }}
           >
             <a className="nav-item" href="#settings">
               <Settings size={20} aria-hidden="true" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -544,6 +544,10 @@ export function App() {
     [addGraphConnection],
   );
 
+  const clearCanvasSelection = useCallback(() => {
+    setSelectedNodeId(null);
+  }, []);
+
   const handleCanvasNodesChange = useCallback(
     (changes: NodeChange<GraphFlowNode>[]) => {
       const rawPositionUpdates = changes.flatMap(
@@ -919,12 +923,21 @@ export function App() {
             <h2>Graph studio workspace</h2>
           </div>
 
-          <section className="graph-canvas" aria-label="Graph canvas">
+          <section
+            className="graph-canvas"
+            aria-label="Graph canvas"
+            onClick={(event) => {
+              if (event.target === event.currentTarget) {
+                clearCanvasSelection();
+              }
+            }}
+          >
             <ReactFlow
               nodes={canvasNodes}
               edges={canvasEdges}
               nodeTypes={nodeTypes}
               onConnect={handleReactFlowConnect}
+              onPaneClick={clearCanvasSelection}
               onNodesChange={handleCanvasNodesChange}
               onNodeDragStart={(_, node) => setDraggedNodeId(node.id)}
               onNodeDragStop={() => setDraggedNodeId(null)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -871,7 +871,7 @@ export function App() {
       </header>
 
       {projectToast ? (
-        <div className="project-toast" role="status">
+        <div className="editor-toast project-toast" role="status">
           {projectToast}
         </div>
       ) : null}
@@ -1029,7 +1029,7 @@ export function App() {
           ) : null}
 
           {connectionFeedback ? (
-            <div className="connection-feedback" role="alert">
+            <div className="editor-toast connection-feedback" role="alert">
               <AlertTriangle size={16} aria-hidden="true" />
               <span>{connectionFeedback}</span>
             </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -374,9 +374,14 @@ h4 {
 }
 
 .editor-toast {
+  position: fixed;
+  left: 50%;
+  top: 60px;
+  z-index: 60;
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  max-width: min(420px, calc(100vw - 36px));
   padding: 10px 12px;
   color: var(--ink);
   background: rgb(15 23 42 / 94%);
@@ -386,15 +391,24 @@ h4 {
   font-size: 0.82rem;
   font-weight: 700;
   line-height: 1.3;
+  pointer-events: none;
+  transform: translateX(-50%);
 }
 
-.project-toast {
-  position: fixed;
-  left: 50%;
-  top: 60px;
-  z-index: 60;
-  max-width: min(360px, calc(100vw - 36px));
-  transform: translateX(-50%);
+.editor-toast.success {
+  border-color: rgb(20 184 166 / 35%);
+}
+
+.editor-toast.info {
+  border-color: rgb(59 130 246 / 35%);
+}
+
+.editor-toast.error {
+  border-color: rgb(239 68 68 / 45%);
+}
+
+.editor-toast svg {
+  flex: 0 0 auto;
 }
 
 .editor-main {
@@ -896,19 +910,6 @@ h4 {
   background: var(--danger);
   outline: none;
   box-shadow: 0 0 0 3px rgb(180 35 24 / 18%);
-}
-
-.connection-feedback {
-  grid-row: 3;
-  position: static;
-  justify-self: start;
-  z-index: 2;
-  width: min(540px, calc(100% - 36px));
-  pointer-events: none;
-}
-
-.connection-feedback svg {
-  margin-top: 1px;
 }
 
 .inspector-panel {

--- a/src/styles.css
+++ b/src/styles.css
@@ -72,6 +72,7 @@ a {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   height: 48px;
   padding: 0 16px;
   color: #ffffff;
@@ -79,6 +80,13 @@ a {
   border-bottom: 1px solid var(--border);
   box-shadow: 0 1px 20px 0 rgba(0, 0, 0, 0.2);
   z-index: 10;
+}
+
+.topbar-project-status {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 24px;
 }
 
 .editor-shell {
@@ -210,6 +218,10 @@ h4 {
   height: 1px;
   margin: 4px 0;
   background: var(--border);
+}
+
+.utility-nav-list {
+  margin-top: auto;
 }
 
 .topbar-project {
@@ -761,6 +773,7 @@ h4 {
 }
 
 .connection-drawer {
+  grid-row: 4;
   overflow: hidden;
   background: var(--surface);
   border: 1px solid var(--border);
@@ -886,10 +899,10 @@ h4 {
 }
 
 .connection-feedback {
-  position: absolute;
-  left: 18px;
-  bottom: 18px;
-  z-index: 20;
+  grid-row: 3;
+  position: static;
+  justify-self: start;
+  z-index: 2;
   width: min(540px, calc(100% - 36px));
   pointer-events: none;
 }
@@ -1067,14 +1080,31 @@ h4 {
   }
 
   .app-topbar {
-    grid-template-columns: 1fr;
-    gap: 10px;
+    flex-wrap: wrap;
+    align-content: center;
+    height: auto;
+    min-height: 48px;
+    gap: 8px;
     padding: 12px;
   }
 
-  .topbar-project,
+  .topbar-project-status {
+    flex: 1 1 240px;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+  }
+
+  .topbar-project {
+    flex: 1 1 220px;
+    flex-wrap: wrap;
+  }
+
   .status-pill {
-    justify-self: start;
+    flex: 0 0 auto;
+  }
+
+  .topbar-actions {
+    margin-left: auto;
   }
 
   .editor-shell {
@@ -1083,16 +1113,40 @@ h4 {
     min-height: calc(100vh - 48px);
   }
 
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    overflow-x: auto;
+    padding: 6px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
   .nav-list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    display: flex;
+    gap: 4px;
+    padding: 0;
+  }
+
+  .utility-nav-list {
+    margin-top: 0;
+    margin-left: auto;
   }
 
   .nav-item {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    gap: 4px;
-    min-height: 60px;
-    text-align: center;
+    width: 36px;
+    height: 36px;
+    min-height: 36px;
+    flex: 0 0 36px;
+    border-radius: 8px;
+  }
+
+  .nav-separator {
+    width: 1px;
+    height: 24px;
+    margin: 6px 2px;
   }
 
   .project-file-actions {

--- a/src/styles.css
+++ b/src/styles.css
@@ -361,6 +361,21 @@ h4 {
   clip-path: inset(50%);
 }
 
+.editor-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  color: var(--ink);
+  background: rgb(15 23 42 / 94%);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: var(--shadow-node);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
 .project-toast {
   position: fixed;
   left: 50%;
@@ -368,15 +383,6 @@ h4 {
   z-index: 60;
   max-width: min(360px, calc(100vw - 36px));
   transform: translateX(-50%);
-  padding: 10px 12px;
-  color: #dcfce7;
-  background: rgba(4, 47, 46, 0.96);
-  border: 1px solid rgba(45, 212, 191, 0.32);
-  border-radius: 8px;
-  box-shadow: 0 16px 34px rgb(0 0 0 / 32%);
-  font-size: 0.84rem;
-  font-weight: 720;
-  line-height: 1.3;
 }
 
 .editor-main {
@@ -884,20 +890,7 @@ h4 {
   left: 18px;
   bottom: 18px;
   z-index: 20;
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr);
-  align-items: start;
-  gap: 8px;
   width: min(540px, calc(100% - 36px));
-  padding: 10px 12px;
-  color: #fbbf24;
-  background: rgba(120, 80, 0, 0.35);
-  border: 1px solid rgba(251, 191, 36, 0.3);
-  border-radius: 8px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
-  font-size: 0.84rem;
-  font-weight: 720;
-  line-height: 1.3;
   pointer-events: none;
 }
 

--- a/src/useEditorToast.test.tsx
+++ b/src/useEditorToast.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useEditorToast } from "./useEditorToast";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useEditorToast", () => {
+  it("shows one toast and replaces the previous toast", () => {
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({ message: "Project exported.", tone: "success" });
+    });
+
+    expect(result.current.toast).toEqual({
+      message: "Project exported.",
+      tone: "success",
+    });
+
+    act(() => {
+      result.current.showToast({
+        message: "That connection already exists.",
+        tone: "error",
+      });
+    });
+
+    expect(result.current.toast).toEqual({
+      message: "That connection already exists.",
+      tone: "error",
+    });
+  });
+
+  it("clears success and info toasts after three seconds", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({ message: "Project reset.", tone: "success" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2999);
+    });
+
+    expect(result.current.toast?.message).toBe("Project reset.");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.toast).toBeNull();
+
+    act(() => {
+      result.current.showToast({ message: "Ready.", tone: "info" });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.toast).toBeNull();
+  });
+
+  it("keeps error toasts visible for five seconds", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({
+        message: "Project file could not be read.",
+        tone: "error",
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+
+    expect(result.current.toast?.message).toBe(
+      "Project file could not be read.",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.toast).toBeNull();
+  });
+
+  it("clears the active toast on demand", () => {
+    const { result } = renderHook(() => useEditorToast());
+
+    act(() => {
+      result.current.showToast({ message: "Project imported.", tone: "success" });
+    });
+    act(() => {
+      result.current.clearToast();
+    });
+
+    expect(result.current.toast).toBeNull();
+  });
+});

--- a/src/useEditorToast.test.tsx
+++ b/src/useEditorToast.test.tsx
@@ -12,7 +12,10 @@ describe("useEditorToast", () => {
     const { result } = renderHook(() => useEditorToast());
 
     act(() => {
-      result.current.showToast({ message: "Project exported.", tone: "success" });
+      result.current.showToast({
+        message: "Project exported.",
+        tone: "success",
+      });
     });
 
     expect(result.current.toast).toEqual({
@@ -94,7 +97,10 @@ describe("useEditorToast", () => {
     const { result } = renderHook(() => useEditorToast());
 
     act(() => {
-      result.current.showToast({ message: "Project imported.", tone: "success" });
+      result.current.showToast({
+        message: "Project imported.",
+        tone: "success",
+      });
     });
     act(() => {
       result.current.clearToast();

--- a/src/useEditorToast.ts
+++ b/src/useEditorToast.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type EditorToastTone = "success" | "info" | "error";
+
+export type EditorToast = {
+  message: string;
+  tone: EditorToastTone;
+};
+
+const editorToastDurations: Record<EditorToastTone, number> = {
+  success: 3000,
+  info: 3000,
+  error: 5000,
+};
+
+export function useEditorToast() {
+  const [toast, setToast] = useState<EditorToast | null>(null);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setToast(null);
+    }, editorToastDurations[toast.tone]);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [toast]);
+
+  const showToast = useCallback((nextToast: EditorToast) => {
+    setToast(nextToast);
+  }, []);
+
+  const clearToast = useCallback(() => {
+    setToast(null);
+  }, []);
+
+  return {
+    toast,
+    showToast,
+    clearToast,
+  };
+}

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -1,14 +1,9 @@
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
 import { readTextFile, useProjectFileWorkflow } from "./useProjectFileWorkflow";
+import type { EditorToast } from "./useEditorToast";
 import type { GraphConnection, GraphNode } from "./projectFile";
 
 afterEach(() => {
@@ -78,6 +73,7 @@ function WorkflowHarness({
   const [connectionFeedback, setConnectionFeedback] = useState<string | null>(
     "Existing feedback",
   );
+  const [lastToast, setLastToast] = useState<EditorToast | null>(null);
   const [draggedNodeId, setDraggedNodeId] = useState<string | null>("tensor");
   const workflow = useProjectFileWorkflow({
     graphNodes,
@@ -90,6 +86,7 @@ function WorkflowHarness({
     clearConnectionSource: () => setConnectionSourceId(null),
     clearConnectionFeedback: () => setConnectionFeedback(null),
     clearDraggedNode: () => setDraggedNodeId(null),
+    showToast: setLastToast,
   });
 
   return (
@@ -115,7 +112,9 @@ function WorkflowHarness({
       <output aria-label="menu state">
         {workflow.isProjectActionsOpen ? "open" : "closed"}
       </output>
-      <output aria-label="toast">{workflow.projectToast ?? "none"}</output>
+      <output aria-label="toast">
+        {lastToast ? `${lastToast.tone}: ${lastToast.message}` : "none"}
+      </output>
       <output aria-label="nodes">
         {graphNodes.map((node) => node.id).join(",")}
       </output>
@@ -215,7 +214,7 @@ describe("useProjectFileWorkflow", () => {
         "dl-graph-studio-project.json",
       );
       expect(screen.getByLabelText("toast")).toHaveTextContent(
-        "Project exported.",
+        "success: Project exported.",
       );
       expect(screen.getByLabelText("menu state")).toHaveTextContent(/^closed$/);
       expect(blobParts).toHaveLength(1);
@@ -270,7 +269,7 @@ describe("useProjectFileWorkflow", () => {
       /^connection-tensor-dense$/,
     );
     expect(screen.getByLabelText("toast")).toHaveTextContent(
-      "Project imported.",
+      "success: Project imported.",
     );
     expect(screen.getByLabelText("menu state")).toHaveTextContent(/^closed$/);
     expect(screen.getByLabelText("selected")).toHaveTextContent(/^none$/);
@@ -297,9 +296,7 @@ describe("useProjectFileWorkflow", () => {
     fireEvent.change(fileInput, { target: { files: [invalidFile] } });
 
     await waitFor(() =>
-      expect(screen.getByLabelText("toast")).toHaveTextContent(
-        "Project file is not valid JSON.",
-      ),
+      expect(screen.getByLabelText("toast")).toHaveTextContent(/^error: /),
     );
     expect(screen.getByLabelText("menu state")).toHaveTextContent(/^open$/);
     expect(screen.getByLabelText("nodes")).toHaveTextContent(/^tensor$/);
@@ -330,7 +327,7 @@ describe("useProjectFileWorkflow", () => {
 
     await waitFor(() =>
       expect(screen.getByLabelText("toast")).toHaveTextContent(
-        "Project file could not be read.",
+        "error: Project file could not be read.",
       ),
     );
     expect(screen.getByLabelText("menu state")).toHaveTextContent(/^open$/);
@@ -351,7 +348,9 @@ describe("useProjectFileWorkflow", () => {
 
     expect(screen.getByLabelText("nodes")).toHaveTextContent(/^tensor$/);
     expect(screen.getByLabelText("connections")).toHaveTextContent(/^none$/);
-    expect(screen.getByLabelText("toast")).toHaveTextContent("Project reset.");
+    expect(screen.getByLabelText("toast")).toHaveTextContent(
+      "success: Project reset.",
+    );
     expect(screen.getByLabelText("menu state")).toHaveTextContent(/^closed$/);
     expect(screen.getByLabelText("selected")).toHaveTextContent(/^none$/);
     expect(screen.getByLabelText("connection source")).toHaveTextContent(
@@ -363,21 +362,4 @@ describe("useProjectFileWorkflow", () => {
     expect(screen.getByLabelText("dragged")).toHaveTextContent(/^none$/);
   });
 
-  it("clears project toasts after three seconds", () => {
-    vi.useFakeTimers();
-
-    render(<WorkflowHarness />);
-
-    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
-
-    expect(screen.getByLabelText("toast")).toHaveTextContent("Project reset.");
-
-    act(() => {
-      vi.advanceTimersByTime(3000);
-    });
-
-    expect(screen.getByLabelText("toast")).toHaveTextContent(/^none$/);
-
-    vi.useRealTimers();
-  });
 });

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -361,5 +361,4 @@ describe("useProjectFileWorkflow", () => {
     );
     expect(screen.getByLabelText("dragged")).toHaveTextContent(/^none$/);
   });
-
 });

--- a/src/useProjectFileWorkflow.ts
+++ b/src/useProjectFileWorkflow.ts
@@ -25,7 +25,7 @@ type UseProjectFileWorkflowOptions = {
   clearConnectionSource: () => void;
   clearConnectionFeedback: () => void;
   clearDraggedNode: () => void;
-  showToast?: (toast: EditorToast) => void;
+  showToast: (toast: EditorToast) => void;
 };
 
 export function readTextFile(file: File) {
@@ -72,16 +72,7 @@ export function useProjectFileWorkflow({
   showToast,
 }: UseProjectFileWorkflowOptions) {
   const [isProjectActionsOpen, setIsProjectActionsOpen] = useState(false);
-  const [projectToast, setProjectToast] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-
-  const emitProjectToast = useCallback(
-    (toast: EditorToast) => {
-      showToast?.(toast);
-      setProjectToast(toast.message);
-    },
-    [showToast],
-  );
 
   const clearEditorWorkflowState = useCallback(() => {
     clearSelectedNode();
@@ -118,9 +109,9 @@ export function useProjectFileWorkflow({
     projectLink.click();
     projectLink.remove();
     URL.revokeObjectURL(projectUrl);
-    emitProjectToast({ message: "Project exported.", tone: "success" });
+    showToast({ message: "Project exported.", tone: "success" });
     setIsProjectActionsOpen(false);
-  }, [graphNodes, graphConnections, emitProjectToast]);
+  }, [graphNodes, graphConnections, showToast]);
 
   const importProjectFile = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -135,7 +126,7 @@ export function useProjectFileWorkflow({
       try {
         projectFileContent = await readTextFile(selectedFile);
       } catch {
-        emitProjectToast({
+        showToast({
           message: "Project file could not be read.",
           tone: "error",
         });
@@ -146,7 +137,7 @@ export function useProjectFileWorkflow({
       const parsedProject = parseProjectFileContent(projectFileContent);
 
       if (!parsedProject.ok) {
-        emitProjectToast({ message: parsedProject.message, tone: "error" });
+        showToast({ message: parsedProject.message, tone: "error" });
         event.target.value = "";
         return;
       }
@@ -154,37 +145,31 @@ export function useProjectFileWorkflow({
       setGraphNodes(parsedProject.project.nodes);
       setGraphConnections(parsedProject.project.connections);
       clearEditorWorkflowState();
-      emitProjectToast({ message: "Project imported.", tone: "success" });
+      showToast({ message: "Project imported.", tone: "success" });
       setIsProjectActionsOpen(false);
       event.target.value = "";
     },
-    [
-      setGraphNodes,
-      setGraphConnections,
-      clearEditorWorkflowState,
-      emitProjectToast,
-    ],
+    [setGraphNodes, setGraphConnections, clearEditorWorkflowState, showToast],
   );
 
   const resetProject = useCallback(() => {
     setGraphNodes(createInitialGraphNodes());
     setGraphConnections([]);
     clearEditorWorkflowState();
-    emitProjectToast({ message: "Project reset.", tone: "success" });
+    showToast({ message: "Project reset.", tone: "success" });
     setIsProjectActionsOpen(false);
   }, [
     setGraphNodes,
     setGraphConnections,
     createInitialGraphNodes,
     clearEditorWorkflowState,
-    emitProjectToast,
+    showToast,
   ]);
 
   return {
     isProjectActionsOpen,
     setIsProjectActionsOpen,
     toggleProjectActions,
-    projectToast,
     fileInputRef,
     openProjectImportPicker,
     exportProjectFile,

--- a/src/useProjectFileWorkflow.ts
+++ b/src/useProjectFileWorkflow.ts
@@ -1,6 +1,5 @@
 import {
   useCallback,
-  useEffect,
   useRef,
   useState,
   type ChangeEvent,
@@ -13,6 +12,7 @@ import {
   parseProjectFileContent,
   serializeProjectFile,
 } from "./projectFile";
+import type { EditorToast } from "./useEditorToast";
 import type { GraphConnection, GraphNode } from "./projectFile";
 
 type UseProjectFileWorkflowOptions = {
@@ -25,6 +25,7 @@ type UseProjectFileWorkflowOptions = {
   clearConnectionSource: () => void;
   clearConnectionFeedback: () => void;
   clearDraggedNode: () => void;
+  showToast?: (toast: EditorToast) => void;
 };
 
 export function readTextFile(file: File) {
@@ -68,24 +69,19 @@ export function useProjectFileWorkflow({
   clearConnectionSource,
   clearConnectionFeedback,
   clearDraggedNode,
+  showToast,
 }: UseProjectFileWorkflowOptions) {
   const [isProjectActionsOpen, setIsProjectActionsOpen] = useState(false);
   const [projectToast, setProjectToast] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  useEffect(() => {
-    if (!projectToast) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setProjectToast(null);
-    }, 3000);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [projectToast]);
+  const emitProjectToast = useCallback(
+    (toast: EditorToast) => {
+      showToast?.(toast);
+      setProjectToast(toast.message);
+    },
+    [showToast],
+  );
 
   const clearEditorWorkflowState = useCallback(() => {
     clearSelectedNode();
@@ -122,9 +118,9 @@ export function useProjectFileWorkflow({
     projectLink.click();
     projectLink.remove();
     URL.revokeObjectURL(projectUrl);
-    setProjectToast("Project exported.");
+    emitProjectToast({ message: "Project exported.", tone: "success" });
     setIsProjectActionsOpen(false);
-  }, [graphNodes, graphConnections]);
+  }, [graphNodes, graphConnections, emitProjectToast]);
 
   const importProjectFile = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -139,7 +135,10 @@ export function useProjectFileWorkflow({
       try {
         projectFileContent = await readTextFile(selectedFile);
       } catch {
-        setProjectToast("Project file could not be read.");
+        emitProjectToast({
+          message: "Project file could not be read.",
+          tone: "error",
+        });
         event.target.value = "";
         return;
       }
@@ -147,7 +146,7 @@ export function useProjectFileWorkflow({
       const parsedProject = parseProjectFileContent(projectFileContent);
 
       if (!parsedProject.ok) {
-        setProjectToast(parsedProject.message);
+        emitProjectToast({ message: parsedProject.message, tone: "error" });
         event.target.value = "";
         return;
       }
@@ -155,24 +154,30 @@ export function useProjectFileWorkflow({
       setGraphNodes(parsedProject.project.nodes);
       setGraphConnections(parsedProject.project.connections);
       clearEditorWorkflowState();
-      setProjectToast("Project imported.");
+      emitProjectToast({ message: "Project imported.", tone: "success" });
       setIsProjectActionsOpen(false);
       event.target.value = "";
     },
-    [setGraphNodes, setGraphConnections, clearEditorWorkflowState],
+    [
+      setGraphNodes,
+      setGraphConnections,
+      clearEditorWorkflowState,
+      emitProjectToast,
+    ],
   );
 
   const resetProject = useCallback(() => {
     setGraphNodes(createInitialGraphNodes());
     setGraphConnections([]);
     clearEditorWorkflowState();
-    setProjectToast("Project reset.");
+    emitProjectToast({ message: "Project reset.", tone: "success" });
     setIsProjectActionsOpen(false);
   }, [
     setGraphNodes,
     setGraphConnections,
     createInitialGraphNodes,
     clearEditorWorkflowState,
+    emitProjectToast,
   ]);
 
   return {


### PR DESCRIPTION
## Summary

- Added the approved Phase 1 UX/UI hardening design and implementation plan.
- Cleared node selection from empty canvas clicks without disrupting node selection.
- Hid the React Flow attribution through the supported `proOptions.hideAttribution` setting.
- Unified project and connection feedback on a shared editor toast surface.
- Applied approved visual findings: responsive nav compaction, 390px topbar wrapping, and connection feedback placement above the connections drawer.

## Linked issue

Closes #22

## Verification

Automated:

- [x] `pnpm lint` passed.
- [x] `pnpm test` passed: 5 files, 51 tests.
- [x] `pnpm build` passed.

Manual:

- [x] Opened the Phase 1 editor flow in the local app.
- [x] Selected primitive and composite nodes and confirmed inspector behavior.
- [x] Edited node parameters during the visual review pass.
- [x] Created valid connections and triggered duplicate-connection feedback.
- [x] Deleted one connection and confirmed the remaining connection flow stayed usable.
- [x] Collapsed and expanded the connections panel.
- [x] Dragged a node and used zoom / fit-view controls during visual review.
- [x] Used project reset and export; opened the import action path.
- [x] Confirmed connection feedback no longer covers the connections drawer.
- [x] Confirmed the 390px topbar no longer overlaps `Ready` with the project title.
- [x] Confirmed the narrow responsive navigation is compact.

## Screenshots / video

Screenshots captured during local browser verification for:

- default editor with duplicate-connection toast above the connections drawer,
- 390px responsive topbar and compact navigation,
- visual review flows covering node selection, inspector, connection drawer, and project actions.

## Visual review gate

| ID | Finding | Decision |
| --- | --- | --- |
| V1 | Connection feedback toast overlaps the Connections drawer and can cover drawer content/delete controls. | Fixed after toast unification did not resolve placement by itself. |
| V2 | Responsive primary navigation occupies a tall band before the canvas in narrow widths. | Fixed. |
| V3 | At 390px, `Ready` overlaps project title text in the topbar. | Fixed. |

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- React Flow attribution removal uses the package-supported `proOptions={{ hideAttribution: true }}` path; no CSS hiding workaround was added.
- The in-app browser did not expose direct viewport resizing, so exact 1440px, 1024px, and 390px responsive checks were performed with temporary iframe wrappers.
