### PR TITLE
[codex] Centralize status and node tag styling

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -106,6 +106,19 @@ describe("App shell", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses named classes for the topbar status indicator", () => {
+    render(<App />);
+
+    const statusLabel = screen.getByText("Ready");
+    const statusPill = statusLabel.closest(".status-pill");
+    const statusDot = statusPill?.querySelector(".status-pill-dot");
+
+    expect(statusPill).toHaveClass("topbar-ready-status");
+    expect(statusPill).not.toHaveAttribute("style");
+    expect(statusDot).toBeInTheDocument();
+    expect(statusDot).not.toHaveAttribute("style");
+  });
+
   it("renders project feedback through the editor toast surface", async () => {
     const user = userEvent.setup();
     const createObjectUrl = vi.fn(() => "blob:project");
@@ -250,9 +263,14 @@ describe("App shell", () => {
     });
 
     expect(
+      within(compositeNode).getByText("Composite"),
+    ).toHaveClass("architecture-node-kind--composite");
+    expect(
       within(inspector).getByRole("heading", { name: /dense block/i }),
     ).toBeInTheDocument();
-    expect(within(inspector).getByText("Composite")).toBeInTheDocument();
+    expect(within(inspector).getByText("Composite")).toHaveClass(
+      "architecture-node-kind--composite",
+    );
     expect(
       within(inspector).getByText(
         "Members: Neuron, Activation, Dense / Linear",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -390,7 +390,9 @@ function CompositeNodeCard({ data }: NodeProps<CompositeFlowNode>) {
       onClick={selectNode}
       onKeyDown={handleKeyDown}
     >
-      <span className="architecture-node-kind">{data.kind}</span>
+      <span className="architecture-node-kind architecture-node-kind--composite">
+        {data.kind}
+      </span>
       <h4>{data.label}</h4>
       <ul>
         {data.displayMetadata.map((item) => (
@@ -766,23 +768,8 @@ export function App() {
             </div>
           </div>
 
-          <div
-            className="status-pill"
-            style={{
-              background: "transparent",
-              border: "none",
-              color: "#10b981",
-              padding: 0,
-            }}
-          >
-            <div
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: "50%",
-                background: "#10b981",
-              }}
-            ></div>
+          <div className="status-pill topbar-ready-status">
+            <div className="status-pill-dot" aria-hidden="true"></div>
             <span>Ready</span>
           </div>
         </div>
@@ -1013,7 +1000,7 @@ export function App() {
           {selectedNode ? (
             <div className="inspector-details">
               <span
-                className={`architecture-node-kind${selectedNode.type === "composite" ? " composite-inspector-tag" : ""}`}
+                className={`architecture-node-kind${selectedNode.type === "composite" ? " architecture-node-kind--composite" : ""}`}
               >
                 {selectedNode.kind}
               </span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -263,6 +263,20 @@ h4 {
   box-shadow: 0 0 10px rgba(45, 212, 191, 0.1);
 }
 
+.topbar-ready-status {
+  padding: 0;
+  color: #10b981;
+  background: transparent;
+  border: none;
+}
+
+.status-pill-dot {
+  width: 6px;
+  height: 6px;
+  background: #10b981;
+  border-radius: 50%;
+}
+
 .topbar-actions {
   position: relative;
   display: flex;
@@ -702,12 +716,6 @@ h4 {
     var(--shadow-node);
 }
 
-.composite-node .architecture-node-kind {
-  color: var(--accent-strong);
-  background: var(--accent-soft);
-  border-color: rgb(255 109 45 / 28%);
-}
-
 .architecture-node-kind {
   width: fit-content;
   padding: 3px 8px;
@@ -719,6 +727,12 @@ h4 {
   font-weight: 780;
   line-height: 1.2;
   text-transform: uppercase;
+}
+
+.architecture-node-kind--composite {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  border-color: rgb(255 109 45 / 28%);
 }
 
 .architecture-node h4 {
@@ -945,12 +959,6 @@ h4 {
   font-weight: 650;
   line-height: 1.3;
   list-style: none;
-}
-
-.inspector-details .architecture-node-kind.composite-inspector-tag {
-  color: var(--accent-strong);
-  background: var(--accent-soft);
-  border-color: rgb(255 109 45 / 28%);
 }
 
 .parameter-form {


### PR DESCRIPTION
## Summary

- Moved the topbar `Ready` status pill and dot presentation from inline styles into named CSS classes.
- Replaced duplicated composite node-kind tag styling with one shared `architecture-node-kind--composite` modifier used by the canvas and inspector.
- Added focused App coverage for the named Ready status classes and the shared composite tag modifier.

## Linked issue

Closes #43

## Verification

Automated:

- [x] `pnpm test` - passed, 7 files / 64 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `git diff --check` - passed.

Manual:

- [x] Opened the editor at `http://127.0.0.1:1420/`.
- [x] Confirmed the topbar `Ready` indicator is present through the named ready status and dot classes.
- [x] Confirmed primitive node kind tags remain present on the canvas.
- [x] Selected `Dense Block` and confirmed the canvas and inspector `Composite` tags both use the shared composite modifier.
- [x] Product owner confirmed the UI works correctly.

## Screenshots / video

Not included. The in-app browser loaded the editor and DOM verification passed, but `Page.captureScreenshot` timed out during capture. This PR preserves the current visual appearance and changes only CSS/markup ownership.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF. Screenshot capture was attempted but timed out; DOM/manual verification is documented above.
- [x] Product-owner manual verification instructions were provided before opening the PR.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes. Not applicable: no behavior, architecture, or workflow documentation changed.

## Notes

- GitHub Project automation was not updated by the agent because the local `gh` token is invalid; product owner authorized continuing while that blocker remains.
