### PR TITLE
[codex] Centralize graph connection validation

### DIFF
--- a/docs/superpowers/plans/2026-05-08-centralize-graph-connection-validation.md
+++ b/docs/superpowers/plans/2026-05-08-centralize-graph-connection-validation.md
@@ -1,0 +1,264 @@
+# Centralize Graph Connection Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize existing graph connection validation so editor-created connections and imported project files use one shared rule source without changing behavior.
+
+**Architecture:** Keep graph model types in `src/projectFile.ts` and add one exported validation helper there because both project import parsing and `App.tsx` already depend on that module. The helper should return a small rule result without UI wording; `App.tsx` maps rule failures to the existing toast messages, while import parsing keeps its existing generic invalid-connections rejection.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, pnpm.
+
+---
+
+### Task 1: Shared Connection Validation Helper
+
+**Files:**
+
+- Modify: `src/projectFile.ts`
+- Test: `src/projectFile.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add exported helper coverage in `src/projectFile.test.ts` before implementation. The tests should prove the same rule helper can validate missing endpoints, self-connections, duplicate source-target pairs, `Data` targets, and valid connections.
+
+```ts
+import {
+  parseProjectFileContent,
+  updateGraphNodePositions,
+  validateGraphConnectionRules,
+} from "./projectFile";
+
+describe("validateGraphConnectionRules", () => {
+  it("rejects missing endpoint nodes", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "input", target: "missing" },
+        project.nodes,
+        [],
+      ),
+    ).toEqual({ isValid: false, reason: "missing-node" });
+  });
+
+  it("rejects self-connections", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "dense", target: "dense" },
+        project.nodes,
+        [],
+      ),
+    ).toEqual({
+      isValid: false,
+      reason: "self-connection",
+      sourceNode: project.nodes[1],
+    });
+  });
+
+  it("rejects duplicate source-target connection pairs", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "input", target: "dense" },
+        project.nodes,
+        project.connections,
+      ),
+    ).toEqual({ isValid: false, reason: "duplicate-connection" });
+  });
+
+  it("rejects connections into Data nodes", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "dense", target: "input" },
+        project.nodes,
+        [],
+      ),
+    ).toEqual({
+      isValid: false,
+      reason: "data-target",
+      targetNode: project.nodes[0],
+    });
+  });
+
+  it("accepts valid connections", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "dense", target: "block" },
+        project.nodes,
+        project.connections,
+      ),
+    ).toEqual({
+      isValid: true,
+      sourceNode: project.nodes[1],
+      targetNode: project.nodes[2],
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/projectFile.test.ts`
+
+Expected: FAIL because `validateGraphConnectionRules` is not exported.
+
+- [ ] **Step 3: Implement the helper**
+
+Add exported types and `validateGraphConnectionRules` to `src/projectFile.ts`. Keep reasons narrow and behavior-only.
+
+```ts
+export type GraphConnectionRuleInput = Pick<
+  GraphConnection,
+  "source" | "target"
+>;
+
+export type GraphConnectionValidationResult =
+  | { isValid: true; sourceNode: GraphNode; targetNode: GraphNode }
+  | { isValid: false; reason: "missing-node" }
+  | { isValid: false; reason: "self-connection"; sourceNode: GraphNode }
+  | { isValid: false; reason: "duplicate-connection" }
+  | { isValid: false; reason: "data-target"; targetNode: GraphNode };
+
+export function validateGraphConnectionRules(
+  connection: GraphConnectionRuleInput,
+  nodes: GraphNode[],
+  existingConnections: GraphConnection[],
+): GraphConnectionValidationResult {
+  const sourceNode = nodes.find((node) => node.id === connection.source);
+  const targetNode = nodes.find((node) => node.id === connection.target);
+
+  if (!sourceNode || !targetNode) {
+    return { isValid: false, reason: "missing-node" };
+  }
+
+  if (connection.source === connection.target) {
+    return { isValid: false, reason: "self-connection", sourceNode };
+  }
+
+  if (
+    existingConnections.some(
+      (existingConnection) =>
+        existingConnection.source === connection.source &&
+        existingConnection.target === connection.target,
+    )
+  ) {
+    return { isValid: false, reason: "duplicate-connection" };
+  }
+
+  if (targetNode.kind === "Data") {
+    return { isValid: false, reason: "data-target", targetNode };
+  }
+
+  return { isValid: true, sourceNode, targetNode };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/projectFile.test.ts`
+
+Expected: PASS.
+
+### Task 2: Reuse Helper In Editor And Import Flows
+
+**Files:**
+
+- Modify: `src/App.tsx`
+- Modify: `src/projectFile.ts`
+- Test: `src/App.test.tsx`
+- Test: `src/projectFile.test.ts`
+
+- [ ] **Step 1: Write a focused failing consistency test**
+
+Add an app-level regression test if missing for the self-connection UI message. Existing tests already cover duplicate and `Data` target messages.
+
+```ts
+it("rejects self-connections with clear feedback", () => {
+  render(<App />);
+
+  fireEvent.click(screen.getByLabelText(/start connection from tensor/i));
+  fireEvent.click(screen.getByLabelText(/cancel connection from tensor/i));
+
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+```
+
+If this test proves the current UI intentionally prevents button-driven self-connections before validation, replace it with a targeted import/helper assertion instead. Do not change UI behavior.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run: `pnpm test src/App.test.tsx src/projectFile.test.ts`
+
+Expected before implementation: existing tests pass; any new helper import test from Task 1 should still drive the production change.
+
+- [ ] **Step 3: Update `App.tsx`**
+
+Import `validateGraphConnectionRules` from `src/projectFile.ts`, remove the duplicated endpoint/duplicate/`Data` rule checks from local `validateGraphConnection`, and keep current toast strings exactly:
+
+```ts
+function validateGraphConnection(
+  sourceId: string,
+  targetId: string,
+  nodes: GraphNode[],
+  connections: GraphConnection[],
+): ConnectionValidationResult {
+  const validation = validateGraphConnectionRules(
+    { source: sourceId, target: targetId },
+    nodes,
+    connections,
+  );
+
+  if (validation.isValid) {
+    return { isValid: true };
+  }
+
+  switch (validation.reason) {
+    case "missing-node":
+      return {
+        isValid: false,
+        message: "Choose two existing nodes before creating a connection.",
+      };
+    case "self-connection":
+      return {
+        isValid: false,
+        message: `${validation.sourceNode.label} cannot connect to itself.`,
+      };
+    case "duplicate-connection":
+      return { isValid: false, message: "That connection already exists." };
+    case "data-target":
+      return {
+        isValid: false,
+        message: `${validation.targetNode.label} is an input node and cannot receive connections.`,
+      };
+  }
+}
+```
+
+- [ ] **Step 4: Update import parsing**
+
+In `parseConnections`, keep duplicate ID checking local, but call `validateGraphConnectionRules(connection, nodes, connections)` after parsing each structurally valid connection. Remove the separate `targetsBySourceId` map and endpoint/kind checks from `parseConnection`.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run: `pnpm test src/App.test.tsx src/projectFile.test.ts`
+
+Expected: PASS with existing toast messages and import rejection behavior unchanged.
+
+- [ ] **Step 6: Run full verification**
+
+Run:
+
+```bash
+pnpm test
+pnpm lint
+pnpm build
+```
+
+Expected: all pass.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,10 @@ import {
 
 import "@xyflow/react/dist/style.css";
 import { ProjectActionsMenu } from "./ProjectActionsMenu";
-import { updateGraphNodePositions } from "./projectFile";
+import {
+  updateGraphNodePositions,
+  validateGraphConnectionRules,
+} from "./projectFile";
 import { useEditorToast } from "./useEditorToast";
 import type {
   CompositeNode,
@@ -215,43 +218,38 @@ function validateGraphConnection(
   nodes: GraphNode[],
   connections: GraphConnection[],
 ): ConnectionValidationResult {
-  const sourceNode = nodes.find((node) => node.id === sourceId);
-  const targetNode = nodes.find((node) => node.id === targetId);
-
-  if (!sourceNode || !targetNode) {
-    return {
-      isValid: false,
-      message: "Choose two existing nodes before creating a connection.",
-    };
-  }
-
-  if (sourceId === targetId) {
-    return {
-      isValid: false,
-      message: `${sourceNode.label} cannot connect to itself.`,
-    };
-  }
-
-  const connectionExists = connections.some(
-    (connection) =>
-      connection.source === sourceId && connection.target === targetId,
+  const validation = validateGraphConnectionRules(
+    { source: sourceId, target: targetId },
+    nodes,
+    connections,
   );
 
-  if (connectionExists) {
-    return {
-      isValid: false,
-      message: "That connection already exists.",
-    };
+  if (validation.isValid) {
+    return { isValid: true };
   }
 
-  if (targetNode.kind === "Data") {
-    return {
-      isValid: false,
-      message: `${targetNode.label} is an input node and cannot receive connections.`,
-    };
+  switch (validation.reason) {
+    case "missing-node":
+      return {
+        isValid: false,
+        message: "Choose two existing nodes before creating a connection.",
+      };
+    case "self-connection":
+      return {
+        isValid: false,
+        message: `${validation.sourceNode.label} cannot connect to itself.`,
+      };
+    case "duplicate-connection":
+      return {
+        isValid: false,
+        message: "That connection already exists.",
+      };
+    case "data-target":
+      return {
+        isValid: false,
+        message: `${validation.targetNode.label} is an input node and cannot receive connections.`,
+      };
   }
-
-  return { isValid: true };
 }
 
 function getGraphConnectionLabel(

--- a/src/projectFile.test.ts
+++ b/src/projectFile.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseProjectFileContent,
   updateGraphNodePositions,
+  validateGraphConnectionRules,
 } from "./projectFile";
 import type { GraphConnection, GraphNode, ProjectFile } from "./projectFile";
 
@@ -163,6 +164,80 @@ describe("parseProjectFileContent", () => {
     expect(parseProject(project)).toEqual({
       ok: true,
       project,
+    });
+  });
+});
+
+describe("validateGraphConnectionRules", () => {
+  it("rejects missing endpoint nodes", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "input", target: "missing" },
+        project.nodes,
+        [],
+      ),
+    ).toEqual({ isValid: false, reason: "missing-node" });
+  });
+
+  it("rejects self-connections", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "dense", target: "dense" },
+        project.nodes,
+        [],
+      ),
+    ).toEqual({
+      isValid: false,
+      reason: "self-connection",
+      sourceNode: project.nodes[1],
+    });
+  });
+
+  it("rejects duplicate source-target connection pairs", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "input", target: "dense" },
+        project.nodes,
+        project.connections,
+      ),
+    ).toEqual({ isValid: false, reason: "duplicate-connection" });
+  });
+
+  it("rejects connections into Data nodes", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "dense", target: "input" },
+        project.nodes,
+        [],
+      ),
+    ).toEqual({
+      isValid: false,
+      reason: "data-target",
+      targetNode: project.nodes[0],
+    });
+  });
+
+  it("accepts valid connections", () => {
+    const project = createValidProjectFile();
+
+    expect(
+      validateGraphConnectionRules(
+        { source: "dense", target: "block" },
+        project.nodes,
+        project.connections,
+      ),
+    ).toEqual({
+      isValid: true,
+      sourceNode: project.nodes[1],
+      targetNode: project.nodes[2],
     });
   });
 });

--- a/src/projectFile.ts
+++ b/src/projectFile.ts
@@ -53,6 +53,18 @@ export type GraphConnection = {
   target: string;
 };
 
+export type GraphConnectionRuleInput = Pick<
+  GraphConnection,
+  "source" | "target"
+>;
+
+export type GraphConnectionValidationResult =
+  | { isValid: true; sourceNode: GraphNode; targetNode: GraphNode }
+  | { isValid: false; reason: "missing-node" }
+  | { isValid: false; reason: "self-connection"; sourceNode: GraphNode }
+  | { isValid: false; reason: "duplicate-connection" }
+  | { isValid: false; reason: "data-target"; targetNode: GraphNode };
+
 export type ProjectFile = {
   version: 1;
   nodes: GraphNode[];
@@ -109,6 +121,39 @@ export function updateGraphNodePositions(
       position: { ...nextPosition },
     };
   });
+}
+
+export function validateGraphConnectionRules(
+  connection: GraphConnectionRuleInput,
+  nodes: GraphNode[],
+  existingConnections: GraphConnection[],
+): GraphConnectionValidationResult {
+  const sourceNode = nodes.find((node) => node.id === connection.source);
+  const targetNode = nodes.find((node) => node.id === connection.target);
+
+  if (!sourceNode || !targetNode) {
+    return { isValid: false, reason: "missing-node" };
+  }
+
+  if (connection.source === connection.target) {
+    return { isValid: false, reason: "self-connection", sourceNode };
+  }
+
+  if (
+    existingConnections.some(
+      (existingConnection) =>
+        existingConnection.source === connection.source &&
+        existingConnection.target === connection.target,
+    )
+  ) {
+    return { isValid: false, reason: "duplicate-connection" };
+  }
+
+  if (targetNode.kind === "Data") {
+    return { isValid: false, reason: "data-target", targetNode };
+  }
+
+  return { isValid: true, sourceNode, targetNode };
 }
 
 export function parseProjectFileContent(
@@ -350,53 +395,31 @@ function parseConnections(
 ): GraphConnection[] | null {
   const connections: GraphConnection[] = [];
   const connectionIds = new Set<string>();
-  const targetsBySourceId = new Map<string, Set<string>>();
-  const nodesById = new Map(nodes.map((node) => [node.id, node]));
 
   for (const value of values) {
-    const connection = parseConnection(value, nodesById);
+    const connection = parseConnection(value);
 
     if (!connection || connectionIds.has(connection.id)) {
       return null;
     }
 
-    const targetsForSource =
-      targetsBySourceId.get(connection.source) ?? new Set<string>();
-
-    if (targetsForSource.has(connection.target)) {
+    if (!validateGraphConnectionRules(connection, nodes, connections).isValid) {
       return null;
     }
 
     connectionIds.add(connection.id);
-    targetsForSource.add(connection.target);
-    targetsBySourceId.set(connection.source, targetsForSource);
     connections.push(connection);
   }
 
   return connections;
 }
 
-function parseConnection(
-  value: unknown,
-  nodesById: Map<string, GraphNode>,
-): GraphConnection | null {
+function parseConnection(value: unknown): GraphConnection | null {
   if (
     !isRecord(value) ||
     !isString(value.id) ||
     !isString(value.source) ||
     !isString(value.target)
-  ) {
-    return null;
-  }
-
-  const sourceNode = nodesById.get(value.source);
-  const targetNode = nodesById.get(value.target);
-
-  if (
-    !sourceNode ||
-    !targetNode ||
-    value.source === value.target ||
-    targetNode.kind === "Data"
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary

- Centralize graph connection validation rules in `projectFile.ts` so editor-created connections and imported project files use the same rule source.
- Reuse the shared validation from `App.tsx` while preserving existing invalid-connection toast messages.
- Reuse the shared validation during project import parsing while preserving the generic invalid-connections import rejection.
- Add focused unit coverage for missing endpoint, self-connection, duplicate connection, `Data` target, and valid connection cases.

## Linked issue

Closes #42

## Verification

Automated:

- [x] `pnpm test` - passed, 7 files / 68 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `pnpm format:check` - passed.
- [x] `git diff --check` - passed.

Manual:

- [x] Opened the editor locally and created `Tensor -> Neuron`; the connection rendered.
- [x] Attempted to create `Tensor -> Neuron` again; the editor showed `That connection already exists.` and did not add a duplicate connection.
- [x] Reset the project and attempted `Neuron -> Tensor`; the editor showed `Tensor is an input node and cannot receive connections.` and did not add the invalid connection.
- [x] Created `/Users/ericdominguezmorales/Downloads/invalid-connection-project.json` with an invalid `dense -> input` connection for product-owner import verification.

## Screenshots / video

Not applicable: this PR centralizes validation logic and preserves existing UI behavior without visual changes.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- The visible editor controls do not currently allow triggering a self-connection toast directly: after starting a connection from a node, that node's control becomes the cancel action. The shared rule still covers self-connections and is verified by automated tests.
- Product-owner manual import check: import `/Users/ericdominguezmorales/Downloads/invalid-connection-project.json` and expect `Project file contains invalid connections.` with no partial import.
