### PR TITLE
[codex] Centralize graph model helpers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { ProjectActionsMenu } from "./ProjectActionsMenu";
 import {
+  cloneGraphNode,
   updateGraphNodePositions,
   validateGraphConnectionRules,
 } from "./projectFile";
@@ -172,15 +173,7 @@ type CompositeFlowNode = Node<CompositeNodeData, "composite">;
 type GraphFlowNode = PrimitiveFlowNode | CompositeFlowNode;
 
 function createInitialGraphNodes() {
-  return [...primitiveNodes, ...compositeNodes].map((node) => ({
-    ...node,
-    metadata: [...node.metadata],
-    parameters: node.parameters.map((parameter) => ({ ...parameter })),
-    ...(node.type === "composite"
-      ? { memberNodeIds: [...node.memberNodeIds] }
-      : {}),
-    position: { ...node.position },
-  }));
+  return [...primitiveNodes, ...compositeNodes].map(cloneGraphNode);
 }
 
 function formatParameterSummary(parameter: PrimitiveNodeParameter) {
@@ -573,29 +566,9 @@ export function App() {
         return;
       }
 
-      setGraphNodes((currentNodes) => {
-        const rawPositionsByNodeId = new Map(
-          rawPositionUpdates.map((update) => [update.id, update.position]),
-        );
-        const positionUpdates = currentNodes.flatMap(
-          (node): GraphNodePositionUpdate[] => {
-            const nextPosition = rawPositionsByNodeId.get(node.id);
-
-            if (!nextPosition) {
-              return [];
-            }
-
-            return [
-              {
-                id: node.id,
-                position: nextPosition,
-              },
-            ];
-          },
-        );
-
-        return updateGraphNodePositions(currentNodes, positionUpdates);
-      });
+      setGraphNodes((currentNodes) =>
+        updateGraphNodePositions(currentNodes, rawPositionUpdates),
+      );
     },
     [],
   );

--- a/src/projectFile.test.ts
+++ b/src/projectFile.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  cloneGraphNode,
   parseProjectFileContent,
   updateGraphNodePositions,
   validateGraphConnectionRules,
@@ -165,6 +166,34 @@ describe("parseProjectFileContent", () => {
       ok: true,
       project,
     });
+  });
+});
+
+describe("cloneGraphNode", () => {
+  it("clones primitive and composite node data without sharing nested references", () => {
+    const project = createValidProjectFile();
+
+    const primitiveClone = cloneGraphNode(project.nodes[0]);
+    const compositeClone = cloneGraphNode(project.nodes[2]);
+
+    expect(primitiveClone).toEqual(project.nodes[0]);
+    expect(compositeClone).toEqual(project.nodes[2]);
+    expect(primitiveClone).not.toBe(project.nodes[0]);
+    expect(compositeClone).not.toBe(project.nodes[2]);
+    expect(primitiveClone.metadata).not.toBe(project.nodes[0].metadata);
+    expect(primitiveClone.parameters).not.toBe(project.nodes[0].parameters);
+    expect(primitiveClone.parameters[0]).not.toBe(project.nodes[0].parameters[0]);
+    expect(primitiveClone.position).not.toBe(project.nodes[0].position);
+
+    if (compositeClone.type !== "composite") {
+      throw new Error("Expected composite clone");
+    }
+
+    expect(compositeClone.memberNodeIds).not.toBe(
+      project.nodes[2].type === "composite"
+        ? project.nodes[2].memberNodeIds
+        : undefined,
+    );
   });
 });
 

--- a/src/projectFile.ts
+++ b/src/projectFile.ts
@@ -88,7 +88,7 @@ export function createProjectFile(
 ): ProjectFile {
   return {
     version: PROJECT_FILE_VERSION,
-    nodes: nodes.map(cloneNode),
+    nodes: nodes.map(cloneGraphNode),
     connections: connections.map((connection) => ({ ...connection })),
   };
 }
@@ -121,6 +121,24 @@ export function updateGraphNodePositions(
       position: { ...nextPosition },
     };
   });
+}
+
+export function cloneGraphNode(node: GraphNode): GraphNode {
+  const clonedNode = {
+    ...node,
+    metadata: [...node.metadata],
+    parameters: node.parameters.map((parameter) => ({ ...parameter })),
+    position: { ...node.position },
+  };
+
+  if (clonedNode.type === "composite") {
+    return {
+      ...clonedNode,
+      memberNodeIds: [...clonedNode.memberNodeIds],
+    };
+  }
+
+  return clonedNode;
 }
 
 export function validateGraphConnectionRules(
@@ -205,24 +223,6 @@ export function parseProjectFileContent(
       connections,
     },
   };
-}
-
-function cloneNode(node: GraphNode): GraphNode {
-  const clonedNode = {
-    ...node,
-    metadata: [...node.metadata],
-    parameters: node.parameters.map((parameter) => ({ ...parameter })),
-    position: { ...node.position },
-  };
-
-  if (clonedNode.type === "composite") {
-    return {
-      ...clonedNode,
-      memberNodeIds: [...clonedNode.memberNodeIds],
-    };
-  }
-
-  return clonedNode;
 }
 
 function parseNodes(values: unknown[]): GraphNode[] | null {


### PR DESCRIPTION
## Summary

- Expose a shared `cloneGraphNode` helper and reuse it for project serialization and default graph initialization.
- Simplify React Flow position updates so `App` passes extracted updates directly to `updateGraphNodePositions`.
- Add focused clone-helper coverage to prove primitive and composite nodes do not share nested references.

## Linked issue

Closes #45

## Verification

Automated:

- [x] `pnpm test` - passed, 7 files and 70 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `git diff --check` - passed.

Manual:

- [x] Open the editor, drag a primitive node, and confirm it stays at the new position.
- [x] Export a project, reset the project, import the exported file, and confirm node positions restore correctly.
- [x] Confirm node labels, metadata, parameters, and composite membership remain intact after reset/import.

## Screenshots / video

Not applicable. This is an internal graph model helper cleanup with no intended UI changes.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- Review focus: confirm the exported clone helper remains a small graph-model utility and that position update handling preserves current drag behavior.
