### PR TITLE
[codex] Centralize project export test setup

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "./App";
+import { setupProjectExportTest } from "./test/projectExportTestHelper";
 
 const originalGetBoundingClientRect =
   HTMLElement.prototype.getBoundingClientRect;
@@ -121,33 +122,35 @@ describe("App shell", () => {
 
   it("renders project feedback through the editor toast surface", async () => {
     const user = userEvent.setup();
-    const createObjectUrl = vi.fn(() => "blob:project");
-    const revokeObjectUrl = vi.fn();
-    const anchorClick = vi
-      .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => undefined);
-    vi.stubGlobal("URL", {
-      ...URL,
+    const {
+      anchorClick,
       createObjectURL: createObjectUrl,
       revokeObjectURL: revokeObjectUrl,
-    });
+      restore,
+    } = setupProjectExportTest({ objectUrl: "blob:project" });
 
-    render(<App />);
+    try {
+      render(<App />);
 
-    await user.click(screen.getByRole("button", { name: /project actions/i }));
-    await user.click(
-      await screen.findByRole("menuitem", { name: /export project/i }),
-    );
+      await user.click(
+        screen.getByRole("button", { name: /project actions/i }),
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: /export project/i }),
+      );
 
-    const toast = screen.getByRole("status");
+      const toast = screen.getByRole("status");
 
-    expect(toast).toHaveClass("editor-toast");
-    expect(toast).toHaveClass("success");
-    expect(toast).toHaveTextContent("Project exported.");
-    expect(createObjectUrl).toHaveBeenCalledTimes(1);
-    expect(anchorClick).toHaveBeenCalledTimes(1);
-    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:project");
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(toast).toHaveClass("editor-toast");
+      expect(toast).toHaveClass("success");
+      expect(toast).toHaveTextContent("Project exported.");
+      expect(createObjectUrl).toHaveBeenCalledTimes(1);
+      expect(anchorClick).toHaveBeenCalledTimes(1);
+      expect(revokeObjectUrl).toHaveBeenCalledWith("blob:project");
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
   });
 
   it("renders deterministic primitive architecture nodes on the canvas", () => {
@@ -782,39 +785,10 @@ describe("App shell", () => {
 
   it("exports the current project from the project actions menu", async () => {
     const user = userEvent.setup();
-    const OriginalBlob = globalThis.Blob;
-    const blobParts: BlobPart[][] = [];
-    const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(
-      URL,
-      "createObjectURL",
-    );
-    const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(
-      URL,
-      "revokeObjectURL",
-    );
-    const createObjectURL = vi.fn(() => "blob:project-file");
-    const revokeObjectURL = vi.fn();
+    const { blobParts, createObjectURL, revokeObjectURL, restore } =
+      setupProjectExportTest();
 
-    vi.stubGlobal(
-      "Blob",
-      vi.fn((parts?: BlobPart[], options?: BlobPropertyBag) => {
-        blobParts.push(parts ?? []);
-        return new OriginalBlob(parts, options);
-      }),
-    );
-    Object.defineProperty(URL, "createObjectURL", {
-      configurable: true,
-      value: createObjectURL,
-    });
-    Object.defineProperty(URL, "revokeObjectURL", {
-      configurable: true,
-      value: revokeObjectURL,
-    });
     try {
-      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
-        () => undefined,
-      );
-
       render(<App />);
 
       fireEvent.click(screen.getByLabelText(/tensor primitive node/i));
@@ -866,25 +840,7 @@ describe("App shell", () => {
         target: "neuron",
       });
     } finally {
-      if (createObjectURLDescriptor) {
-        Object.defineProperty(
-          URL,
-          "createObjectURL",
-          createObjectURLDescriptor,
-        );
-      } else {
-        Reflect.deleteProperty(URL, "createObjectURL");
-      }
-
-      if (revokeObjectURLDescriptor) {
-        Object.defineProperty(
-          URL,
-          "revokeObjectURL",
-          revokeObjectURLDescriptor,
-        );
-      } else {
-        Reflect.deleteProperty(URL, "revokeObjectURL");
-      }
+      restore();
     }
   });
 });

--- a/src/test/projectExportTestHelper.ts
+++ b/src/test/projectExportTestHelper.ts
@@ -1,0 +1,78 @@
+import { vi } from "vitest";
+
+type ProjectExportTestOptions = {
+  objectUrl?: string;
+};
+
+export function setupProjectExportTest({
+  objectUrl = "blob:project-file",
+}: ProjectExportTestOptions = {}) {
+  const OriginalBlob = globalThis.Blob;
+  const blobDescriptor = Object.getOwnPropertyDescriptor(globalThis, "Blob");
+  const blobParts: BlobPart[][] = [];
+  const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(
+    URL,
+    "createObjectURL",
+  );
+  const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(
+    URL,
+    "revokeObjectURL",
+  );
+  const createObjectURL = vi.fn(() => objectUrl);
+  const revokeObjectURL = vi.fn();
+  const anchorClick = vi
+    .spyOn(HTMLAnchorElement.prototype, "click")
+    .mockImplementation(() => undefined);
+
+  vi.stubGlobal(
+    "Blob",
+    vi.fn((parts?: BlobPart[], options?: BlobPropertyBag) => {
+      blobParts.push(parts ?? []);
+      return new OriginalBlob(parts, options);
+    }),
+  );
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: createObjectURL,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: revokeObjectURL,
+  });
+
+  return {
+    anchorClick,
+    blobParts,
+    createObjectURL,
+    revokeObjectURL,
+    restore: () => {
+      anchorClick.mockRestore();
+
+      if (blobDescriptor) {
+        Object.defineProperty(globalThis, "Blob", blobDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "Blob");
+      }
+
+      if (createObjectURLDescriptor) {
+        Object.defineProperty(
+          URL,
+          "createObjectURL",
+          createObjectURLDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(URL, "createObjectURL");
+      }
+
+      if (revokeObjectURLDescriptor) {
+        Object.defineProperty(
+          URL,
+          "revokeObjectURL",
+          revokeObjectURLDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(URL, "revokeObjectURL");
+      }
+    },
+  };
+}

--- a/src/useProjectFileWorkflow.test.tsx
+++ b/src/useProjectFileWorkflow.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
 import { readTextFile, useProjectFileWorkflow } from "./useProjectFileWorkflow";
+import { setupProjectExportTest } from "./test/projectExportTestHelper";
 import type { EditorToast } from "./useEditorToast";
 import type { GraphConnection, GraphNode } from "./projectFile";
 
@@ -141,41 +142,17 @@ describe("useProjectFileWorkflow", () => {
   });
 
   it("exports the current project", () => {
-    const OriginalBlob = globalThis.Blob;
-    const blobParts: BlobPart[][] = [];
-    const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(
-      URL,
-      "createObjectURL",
-    );
-    const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(
-      URL,
-      "revokeObjectURL",
-    );
-    const createObjectURL = vi.fn(() => "blob:project-file");
-    const revokeObjectURL = vi.fn();
+    const {
+      anchorClick,
+      blobParts,
+      createObjectURL,
+      revokeObjectURL,
+      restore,
+    } = setupProjectExportTest();
     const createdAnchors: HTMLAnchorElement[] = [];
     const originalCreateElement = document.createElement.bind(document);
 
-    vi.stubGlobal(
-      "Blob",
-      vi.fn((parts?: BlobPart[], options?: BlobPropertyBag) => {
-        blobParts.push(parts ?? []);
-        return new OriginalBlob(parts, options);
-      }),
-    );
-    Object.defineProperty(URL, "createObjectURL", {
-      configurable: true,
-      value: createObjectURL,
-    });
-    Object.defineProperty(URL, "revokeObjectURL", {
-      configurable: true,
-      value: revokeObjectURL,
-    });
-
     try {
-      const anchorClick = vi
-        .spyOn(HTMLAnchorElement.prototype, "click")
-        .mockImplementation(() => undefined);
       vi.spyOn(document, "createElement").mockImplementation(((
         tagName: string,
         options?: ElementCreationOptions,
@@ -218,25 +195,7 @@ describe("useProjectFileWorkflow", () => {
         connections: editedConnections,
       });
     } finally {
-      if (createObjectURLDescriptor) {
-        Object.defineProperty(
-          URL,
-          "createObjectURL",
-          createObjectURLDescriptor,
-        );
-      } else {
-        Reflect.deleteProperty(URL, "createObjectURL");
-      }
-
-      if (revokeObjectURLDescriptor) {
-        Object.defineProperty(
-          URL,
-          "revokeObjectURL",
-          revokeObjectURLDescriptor,
-        );
-      } else {
-        Reflect.deleteProperty(URL, "revokeObjectURL");
-      }
+      restore();
     }
   });
 


### PR DESCRIPTION
## Summary

- Added a focused test helper for project export setup and cleanup.
- Reused the helper in workflow-level and app-level export tests.
- Preserved existing export assertions while removing duplicated Blob, URL, and anchor scaffolding.

## Linked issue

Closes #44

## Verification

Automated:

- [x] `pnpm test` passed: 7 files, 69 tests.
- [x] `pnpm lint` passed.
- [x] `pnpm build` passed.
- [x] Spec compliance review passed.
- [x] Code quality review approved.

Manual:

- [x] Not required; this is a test-only maintainability cleanup.

## Screenshots / video

Not applicable; this PR does not change UI behavior.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

Review focus: test helper ownership and cleanup behavior. The implementation intentionally avoids production code changes.