### PR TITLE
Extract shared architecture node card

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -284,6 +284,36 @@ describe("App shell", () => {
     ).toBeInTheDocument();
   });
 
+  it("selects primitive and composite nodes from the keyboard", async () => {
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    const neuronNode = screen.getByRole("button", {
+      name: /neuron primitive node/i,
+    });
+    const compositeNode = screen.getByRole("button", {
+      name: /dense block composite node/i,
+    });
+
+    neuronNode.focus();
+    await user.keyboard("{Enter}");
+
+    expect(neuronNode).toHaveAttribute("aria-pressed", "true");
+    expect(compositeNode).toHaveAttribute("aria-pressed", "false");
+
+    compositeNode.focus();
+    await user.keyboard(" ");
+
+    expect(neuronNode).toHaveAttribute("aria-pressed", "false");
+    expect(compositeNode).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(
+        screen.getByRole("complementary", { name: /node inspector/i }),
+      ).getByRole("heading", { name: /dense block/i }),
+    ).toBeInTheDocument();
+  });
+
   it("clears node selection when the empty canvas background is clicked", () => {
     render(<App />);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,9 +267,37 @@ function getFlowNodeSize(node: GraphNode) {
     : primitiveFlowNodeSize;
 }
 
-function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
+type ArchitectureNodeCardSurfaceProps = {
+  id: string;
+  label: string;
+  kind: string;
+  displayMetadata: string[];
+  nodeKindLabel: "primitive" | "composite";
+  isSelected: boolean;
+  isDragging: boolean;
+  onSelect: (id: string) => void;
+  testId: string;
+  variantClassName?: string;
+  stateClassName?: string;
+  kindClassName?: string;
+};
+
+function ArchitectureNodeCardSurface({
+  id,
+  label,
+  kind,
+  displayMetadata,
+  nodeKindLabel,
+  isSelected,
+  isDragging,
+  onSelect,
+  testId,
+  variantClassName,
+  stateClassName,
+  kindClassName,
+}: ArchitectureNodeCardSurfaceProps) {
   const selectNode = () => {
-    data.onSelect(data.id);
+    onSelect(id);
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
@@ -279,9 +307,46 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
     }
   };
 
+  return (
+    <article
+      className={`architecture-node${variantClassName ? ` ${variantClassName}` : ""}${
+        isSelected ? " selected" : ""
+      }${isDragging ? " moving" : ""}${
+        stateClassName ? ` ${stateClassName}` : ""
+      }`}
+      data-testid={testId}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      aria-label={`${label} ${nodeKindLabel} node`}
+      onClick={selectNode}
+      onKeyDown={handleKeyDown}
+    >
+      <span
+        className={`architecture-node-kind${kindClassName ? ` ${kindClassName}` : ""}`}
+      >
+        {kind}
+      </span>
+      <h4>{label}</h4>
+      <ul>
+        {displayMetadata.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
   const isConnectionSource = data.connectionSourceId === data.id;
   const isConnectionTarget =
     data.connectionSourceId !== null && data.connectionSourceId !== data.id;
+  const connectionStateClassName = [
+    isConnectionSource ? "connection-source" : "",
+    isConnectionTarget ? "connection-target" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <div className="architecture-node-shell">
@@ -290,28 +355,18 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
         position={Position.Left}
         className="architecture-node-handle"
       />
-      <article
-        className={`architecture-node${data.isSelected ? " selected" : ""}${
-          data.isDragging ? " moving" : ""
-        }${
-          isConnectionSource ? " connection-source" : ""
-        }${isConnectionTarget ? " connection-target" : ""}`}
-        data-testid="architecture-node"
-        role="button"
-        tabIndex={0}
-        aria-pressed={data.isSelected}
-        aria-label={`${data.label} primitive node`}
-        onClick={selectNode}
-        onKeyDown={handleKeyDown}
-      >
-        <span className="architecture-node-kind">{data.kind}</span>
-        <h4>{data.label}</h4>
-        <ul>
-          {data.displayMetadata.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
-      </article>
+      <ArchitectureNodeCardSurface
+        id={data.id}
+        label={data.label}
+        kind={data.kind}
+        displayMetadata={data.displayMetadata}
+        nodeKindLabel="primitive"
+        isSelected={data.isSelected}
+        isDragging={data.isDragging}
+        onSelect={data.onSelect}
+        testId="architecture-node"
+        stateClassName={connectionStateClassName}
+      />
       <div className="connection-controls">
         {isConnectionSource ? (
           <button
@@ -357,40 +412,20 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
 }
 
 function CompositeNodeCard({ data }: NodeProps<CompositeFlowNode>) {
-  const selectNode = () => {
-    data.onSelect(data.id);
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      selectNode();
-    }
-  };
-
   return (
-    <article
-      className={`architecture-node composite-node${
-        data.isSelected ? " selected" : ""
-      }${data.isDragging ? " moving" : ""}`}
-      data-testid="composite-node"
-      role="button"
-      tabIndex={0}
-      aria-pressed={data.isSelected}
-      aria-label={`${data.label} composite node`}
-      onClick={selectNode}
-      onKeyDown={handleKeyDown}
-    >
-      <span className="architecture-node-kind architecture-node-kind--composite">
-        {data.kind}
-      </span>
-      <h4>{data.label}</h4>
-      <ul>
-        {data.displayMetadata.map((item) => (
-          <li key={item}>{item}</li>
-        ))}
-      </ul>
-    </article>
+    <ArchitectureNodeCardSurface
+      id={data.id}
+      label={data.label}
+      kind={data.kind}
+      displayMetadata={data.displayMetadata}
+      nodeKindLabel="composite"
+      isSelected={data.isSelected}
+      isDragging={data.isDragging}
+      onSelect={data.onSelect}
+      testId="composite-node"
+      variantClassName="composite-node"
+      kindClassName="architecture-node-kind--composite"
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- Extracted a shared `ArchitectureNodeCardSurface` for primitive and composite node card rendering.
- Kept primitive-only connection handles and controls outside the shared surface.
- Added keyboard selection coverage for primitive and composite node cards.

## Linked issue

Closes #46

## Verification

Automated:

- [x] `pnpm test` passed: 7 files, 71 tests.
- [x] `pnpm lint` passed.
- [x] `pnpm build` passed.
- [x] `git diff --check` passed.

Manual:

- [x] Opened the editor at `http://127.0.0.1:1420/` and confirmed the graph canvas, primitive nodes, composite node, and inspector rendered.
- [x] Product owner confirmed the current result in-thread.

## Screenshots / video

Not applicable: this is a rendering refactor intended to preserve the existing visual design. A Codex browser check confirmed the editor rendered with primitive nodes, the Dense Block composite node, and the inspector visible.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

Review focus: confirm the shared card surface remains limited to the duplicated article-level rendering and that connection behavior stays primitive-only.
