### PR TITLE
[codex] Centralize editor icon buttons

### DIFF
--- a/docs/superpowers/plans/2026-05-08-centralize-editor-icon-buttons.md
+++ b/docs/superpowers/plans/2026-05-08-centralize-editor-icon-buttons.md
@@ -1,0 +1,207 @@
+# Centralize Editor Icon Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize existing icon-only editor buttons behind one focused primitive while preserving current accessibility labels, titles, visual variants, and interactions.
+
+**Architecture:** Add a small `EditorIconButton` component that owns the repeated `<button type="button">`, `aria-label`, default `title`, icon-only rendering, ref forwarding for Radix `asChild`, and shared class composition. Keep all behavior in callers and all visual variants in existing CSS class names so the PR stays a local cleanup.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, Radix DropdownMenu, lucide-react, plain CSS.
+
+---
+
+### Task 1: Add The Icon-Only Button Primitive
+
+**Files:**
+
+- Create: `src/EditorIconButton.tsx`
+- Create: `src/EditorIconButton.test.tsx`
+
+- [ ] **Step 1: Write the failing primitive contract tests**
+
+Create `src/EditorIconButton.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MoreVertical } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditorIconButton } from "./EditorIconButton";
+
+describe("EditorIconButton", () => {
+  it("renders an icon-only button with a label and default title", () => {
+    render(
+      <EditorIconButton label="Project actions" icon={<MoreVertical />} />,
+    );
+
+    const button = screen.getByRole("button", { name: "Project actions" });
+
+    expect(button).toHaveAttribute("type", "button");
+    expect(button).toHaveAttribute("title", "Project actions");
+    expect(button).toHaveClass("editor-icon-button");
+    expect(button.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("preserves caller props, custom title, classes, disabled state, and clicks", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <EditorIconButton
+        label="Run graph coming soon"
+        title="Custom run title"
+        icon={<MoreVertical />}
+        className="future-action"
+        disabled
+        aria-expanded={false}
+        onClick={onClick}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Run graph coming soon",
+    });
+
+    expect(button).toHaveAttribute("title", "Custom run title");
+    expect(button).toHaveClass("editor-icon-button", "future-action");
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(button);
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `pnpm test -- src/EditorIconButton.test.tsx`
+
+Expected: FAIL because `src/EditorIconButton.tsx` does not exist yet.
+
+- [ ] **Step 3: Implement the primitive**
+
+Create `src/EditorIconButton.tsx`:
+
+```tsx
+import { forwardRef } from "react";
+
+type EditorIconButtonProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "children" | "aria-label"
+> & {
+  icon: React.ReactNode;
+  label: string;
+};
+
+export const EditorIconButton = forwardRef<
+  HTMLButtonElement,
+  EditorIconButtonProps
+>(function EditorIconButton(
+  { className, icon, label, title = label, type = "button", ...buttonProps },
+  ref,
+) {
+  const buttonClassName = className
+    ? `editor-icon-button ${className}`
+    : "editor-icon-button";
+
+  return (
+    <button
+      {...buttonProps}
+      ref={ref}
+      type={type}
+      className={buttonClassName}
+      aria-label={label}
+      title={title}
+    >
+      {icon}
+    </button>
+  );
+});
+```
+
+- [ ] **Step 4: Run the primitive test and verify it passes**
+
+Run: `pnpm test -- src/EditorIconButton.test.tsx`
+
+Expected: PASS.
+
+### Task 2: Migrate Existing Editor Icon Buttons
+
+**Files:**
+
+- Modify: `src/App.tsx`
+- Modify: `src/ProjectActionsMenu.tsx`
+- Modify: `src/styles.css`
+- Test: `src/App.test.tsx`
+- Test: `src/ProjectActionsMenu.test.tsx`
+- Test: `src/EditorIconButton.test.tsx`
+
+- [ ] **Step 1: Import and use the primitive in app/editor controls**
+
+In `src/App.tsx`, import the primitive:
+
+```tsx
+import { EditorIconButton } from "./EditorIconButton";
+```
+
+Replace:
+
+- connection cancel button with `EditorIconButton` using `className="connection-button cancel nodrag"`, label/title `Cancel connection from ${data.label}`, icon `<X size={15} aria-hidden="true" />`, and existing click handler.
+- connection start/complete button with `EditorIconButton` using `className="connection-button nodrag"`, the existing dynamic label as both label and title, icon `<Link2 size={15} aria-hidden="true" />`, and existing click handler.
+- each disabled topbar future action button with `EditorIconButton` using `className="topbar-icon-button future-action"`, existing label/title, existing icon, and `disabled`.
+- connections drawer toggle with `EditorIconButton` using `className="connection-drawer-toggle"`, `aria-expanded={!isConnectionsPanelCollapsed}`, label/title `connectionsPanelToggleLabel`, icon `<ChevronDown size={16} aria-hidden="true" />`, and existing click handler.
+- connection delete button with `EditorIconButton` using `className="connection-delete-button"`, label/title `getDeleteConnectionLabel(connectionLabel)`, icon `<Trash2 size={13} aria-hidden="true" />`, and existing click handler.
+
+- [ ] **Step 2: Use the primitive as the Radix trigger child**
+
+In `src/ProjectActionsMenu.tsx`, import the primitive:
+
+```tsx
+import { EditorIconButton } from "./EditorIconButton";
+```
+
+Replace the trigger `<button>` with:
+
+```tsx
+<EditorIconButton
+  className="topbar-icon-button"
+  label="Project actions"
+  icon={<MoreVertical size={18} aria-hidden="true" />}
+/>
+```
+
+- [ ] **Step 3: Centralize the CSS base without visual changes**
+
+In `src/styles.css`, add a base selector named `.editor-icon-button` with the common icon-only button declarations:
+
+```css
+.editor-icon-button {
+  display: inline-grid;
+  place-items: center;
+  border-radius: 8px;
+  cursor: pointer;
+}
+```
+
+Then remove only the duplicated `display: inline-grid`, `place-items: center`, and `cursor: pointer` declarations from `.topbar-icon-button`, `.connection-button`, `.connection-drawer-toggle`, and `.connection-delete-button`. Keep all existing sizes, colors, borders, transitions, hover/focus states, disabled/future-action rules, and per-control radii.
+
+- [ ] **Step 4: Run focused behavior tests**
+
+Run: `pnpm test -- src/EditorIconButton.test.tsx src/ProjectActionsMenu.test.tsx src/App.test.tsx`
+
+Expected: PASS. Existing tests should continue to prove project actions, connection controls, drawer toggle, delete behavior, and topbar labels still work.
+
+- [ ] **Step 5: Run full verification**
+
+Run:
+
+```bash
+pnpm test
+pnpm lint
+pnpm build
+```
+
+Expected: all PASS.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -265,9 +265,9 @@ describe("App shell", () => {
       name: /node inspector/i,
     });
 
-    expect(
-      within(compositeNode).getByText("Composite"),
-    ).toHaveClass("architecture-node-kind--composite");
+    expect(within(compositeNode).getByText("Composite")).toHaveClass(
+      "architecture-node-kind--composite",
+    );
     expect(
       within(inspector).getByRole("heading", { name: /dense block/i }),
     ).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import {
 } from "@xyflow/react";
 
 import "@xyflow/react/dist/style.css";
+import { EditorIconButton } from "./EditorIconButton";
 import { ProjectActionsMenu } from "./ProjectActionsMenu";
 import {
   cloneGraphNode,
@@ -282,6 +283,9 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
   const isConnectionSource = data.connectionSourceId === data.id;
   const isConnectionTarget =
     data.connectionSourceId !== null && data.connectionSourceId !== data.id;
+  const connectionButtonLabel = data.connectionSourceId
+    ? `Connect ${data.connectionSourceLabel} to ${data.label}`
+    : `Start connection from ${data.label}`;
 
   return (
     <div className="architecture-node-shell">
@@ -314,37 +318,25 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
       </article>
       <div className="connection-controls">
         {isConnectionSource ? (
-          <button
-            type="button"
+          <EditorIconButton
             className="connection-button cancel nodrag"
-            aria-label={`Cancel connection from ${data.label}`}
+            label={`Cancel connection from ${data.label}`}
             title={`Cancel connection from ${data.label}`}
+            icon={<X size={15} aria-hidden="true" />}
             onClick={data.onCancelConnection}
-          >
-            <X size={15} aria-hidden="true" />
-          </button>
+          />
         ) : (
-          <button
-            type="button"
+          <EditorIconButton
             className="connection-button nodrag"
-            aria-label={
-              data.connectionSourceId
-                ? `Connect ${data.connectionSourceLabel} to ${data.label}`
-                : `Start connection from ${data.label}`
-            }
-            title={
-              data.connectionSourceId
-                ? `Connect ${data.connectionSourceLabel} to ${data.label}`
-                : `Start connection from ${data.label}`
-            }
+            label={connectionButtonLabel}
+            title={connectionButtonLabel}
+            icon={<Link2 size={15} aria-hidden="true" />}
             onClick={() =>
               data.connectionSourceId
                 ? data.onCompleteConnection(data.id)
                 : data.onStartConnection(data.id)
             }
-          >
-            <Link2 size={15} aria-hidden="true" />
-          </button>
+          />
         )}
       </div>
       <Handle
@@ -746,42 +738,34 @@ export function App() {
         </div>
 
         <div className="topbar-actions" aria-label="Editor actions">
-          <button
-            type="button"
+          <EditorIconButton
             className="topbar-icon-button future-action"
             disabled
+            label="Undo coming soon"
             title="Undo coming soon"
-            aria-label="Undo coming soon"
-          >
-            <Undo2 size={18} aria-hidden="true" />
-          </button>
-          <button
-            type="button"
+            icon={<Undo2 size={18} aria-hidden="true" />}
+          />
+          <EditorIconButton
             className="topbar-icon-button future-action"
             disabled
+            label="Redo coming soon"
             title="Redo coming soon"
-            aria-label="Redo coming soon"
-          >
-            <Redo2 size={18} aria-hidden="true" />
-          </button>
-          <button
-            type="button"
+            icon={<Redo2 size={18} aria-hidden="true" />}
+          />
+          <EditorIconButton
             className="topbar-icon-button future-action"
             disabled
+            label="Run graph coming soon"
             title="Run graph coming soon"
-            aria-label="Run graph coming soon"
-          >
-            <Play size={18} aria-hidden="true" />
-          </button>
-          <button
-            type="button"
+            icon={<Play size={18} aria-hidden="true" />}
+          />
+          <EditorIconButton
             className="topbar-icon-button future-action"
             disabled
+            label="Native save coming soon"
             title="Native save coming soon"
-            aria-label="Native save coming soon"
-          >
-            <Save size={18} aria-hidden="true" />
-          </button>
+            icon={<Save size={18} aria-hidden="true" />}
+          />
           <div className="project-actions-menu">
             <ProjectActionsMenu
               onImportProject={openProjectImportPicker}
@@ -918,20 +902,18 @@ export function App() {
                   <h3>Connections</h3>
                   <span>{graphConnections.length}</span>
                 </div>
-                <button
-                  type="button"
+                <EditorIconButton
                   className="connection-drawer-toggle"
                   aria-expanded={!isConnectionsPanelCollapsed}
-                  aria-label={connectionsPanelToggleLabel}
+                  label={connectionsPanelToggleLabel}
                   title={connectionsPanelToggleLabel}
+                  icon={<ChevronDown size={16} aria-hidden="true" />}
                   onClick={() =>
                     setIsConnectionsPanelCollapsed(
                       (currentIsCollapsed) => !currentIsCollapsed,
                     )
                   }
-                >
-                  <ChevronDown size={16} aria-hidden="true" />
-                </button>
+                />
               </header>
               {!isConnectionsPanelCollapsed ? (
                 <div className="connection-list">
@@ -944,15 +926,13 @@ export function App() {
                     return (
                       <div className="connection-list-item" key={connection.id}>
                         <span>{connectionLabel}</span>
-                        <button
-                          type="button"
+                        <EditorIconButton
                           className="connection-delete-button"
-                          aria-label={getDeleteConnectionLabel(connectionLabel)}
+                          label={getDeleteConnectionLabel(connectionLabel)}
                           title={getDeleteConnectionLabel(connectionLabel)}
+                          icon={<Trash2 size={13} aria-hidden="true" />}
                           onClick={() => deleteGraphConnection(connection.id)}
-                        >
-                          <Trash2 size={13} aria-hidden="true" />
-                        </button>
+                        />
                       </div>
                     );
                   })}

--- a/src/EditorIconButton.test.tsx
+++ b/src/EditorIconButton.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MoreVertical } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditorIconButton } from "./EditorIconButton";
+
+describe("EditorIconButton", () => {
+  it("renders an icon-only button with a label and default title", () => {
+    render(
+      <EditorIconButton label="Project actions" icon={<MoreVertical />} />,
+    );
+
+    const button = screen.getByRole("button", { name: "Project actions" });
+
+    expect(button).toHaveAttribute("type", "button");
+    expect(button).toHaveAttribute("title", "Project actions");
+    expect(button).toHaveClass("editor-icon-button");
+    expect(button.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("preserves caller props, custom title, classes, disabled state, and clicks", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <EditorIconButton
+        label="Run graph coming soon"
+        title="Custom run title"
+        icon={<MoreVertical />}
+        className="future-action"
+        disabled
+        aria-expanded={false}
+        onClick={onClick}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Run graph coming soon",
+    });
+
+    expect(button).toHaveAttribute("title", "Custom run title");
+    expect(button).toHaveClass("editor-icon-button", "future-action");
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(button);
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("preserves generic caller props and handles enabled clicks", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <EditorIconButton
+        label="Run graph"
+        icon={<MoreVertical />}
+        data-testid="run-button"
+        onClick={onClick}
+      />,
+    );
+
+    const button = screen.getByTestId("run-button");
+
+    expect(button).toHaveAttribute("data-testid", "run-button");
+
+    await user.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/EditorIconButton.tsx
+++ b/src/EditorIconButton.tsx
@@ -1,0 +1,45 @@
+import { cloneElement, forwardRef, isValidElement } from "react";
+import type {
+  AriaAttributes,
+  ButtonHTMLAttributes,
+  ReactElement,
+  ReactNode,
+} from "react";
+
+type EditorIconButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children" | "aria-label"
+> & {
+  icon: ReactNode;
+  label: string;
+};
+
+export const EditorIconButton = forwardRef<
+  HTMLButtonElement,
+  EditorIconButtonProps
+>(function EditorIconButton(
+  { className, icon, label, title = label, type = "button", ...buttonProps },
+  ref,
+) {
+  const buttonClassName = className
+    ? `editor-icon-button ${className}`
+    : "editor-icon-button";
+  const renderedIcon = isValidElement(icon)
+    ? cloneElement(icon as ReactElement<AriaAttributes>, {
+        "aria-hidden": true,
+      })
+    : icon;
+
+  return (
+    <button
+      {...buttonProps}
+      ref={ref}
+      type={type}
+      className={buttonClassName}
+      aria-label={label}
+      title={title}
+    >
+      {renderedIcon}
+    </button>
+  );
+});

--- a/src/ProjectActionsMenu.tsx
+++ b/src/ProjectActionsMenu.tsx
@@ -1,6 +1,8 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Download, MoreVertical, RotateCcw, Upload } from "lucide-react";
 
+import { EditorIconButton } from "./EditorIconButton";
+
 type ProjectActionsMenuProps = {
   onImportProject: () => void;
   onExportProject: () => void;
@@ -15,14 +17,11 @@ export function ProjectActionsMenu({
   return (
     <DropdownMenu.Root modal={false}>
       <DropdownMenu.Trigger asChild>
-        <button
-          type="button"
+        <EditorIconButton
           className="topbar-icon-button"
-          aria-label="Project actions"
-          title="Project actions"
-        >
-          <MoreVertical size={18} aria-hidden="true" />
-        </button>
+          label="Project actions"
+          icon={<MoreVertical size={18} aria-hidden="true" />}
+        />
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
         <DropdownMenu.Content

--- a/src/projectFile.test.ts
+++ b/src/projectFile.test.ts
@@ -182,7 +182,9 @@ describe("cloneGraphNode", () => {
     expect(compositeClone).not.toBe(project.nodes[2]);
     expect(primitiveClone.metadata).not.toBe(project.nodes[0].metadata);
     expect(primitiveClone.parameters).not.toBe(project.nodes[0].parameters);
-    expect(primitiveClone.parameters[0]).not.toBe(project.nodes[0].parameters[0]);
+    expect(primitiveClone.parameters[0]).not.toBe(
+      project.nodes[0].parameters[0],
+    );
     expect(primitiveClone.position).not.toBe(project.nodes[0].position);
 
     if (compositeClone.type !== "composite") {

--- a/src/styles.css
+++ b/src/styles.css
@@ -284,16 +284,19 @@ h4 {
   gap: 8px;
 }
 
-.topbar-icon-button {
+.editor-icon-button {
   display: inline-grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.topbar-icon-button {
   width: 32px;
   height: 32px;
-  place-items: center;
   color: #ffffff;
   background: transparent;
   border: 1px solid transparent;
   border-radius: 8px;
-  cursor: pointer;
   transition:
     color 0.15s,
     background 0.15s,
@@ -773,16 +776,13 @@ h4 {
 }
 
 .connection-button {
-  display: inline-grid;
   width: 32px;
   height: 32px;
-  place-items: center;
   color: #ffffff;
   background: var(--teal-strong);
   border: 1px solid rgb(8 124 117 / 72%);
   border-radius: 8px;
   box-shadow: 0 8px 18px rgb(17 24 39 / 12%);
-  cursor: pointer;
 }
 
 .connection-button:hover,
@@ -846,16 +846,13 @@ h4 {
 }
 
 .connection-drawer-toggle {
-  display: inline-grid;
   width: 28px;
   height: 28px;
   flex: 0 0 auto;
-  place-items: center;
   color: var(--teal-strong);
   background: var(--teal-soft);
   border: 1px solid rgba(19, 168, 158, 0.25);
   border-radius: 7px;
-  cursor: pointer;
   transition:
     background 0.2s,
     color 0.2s,
@@ -905,15 +902,12 @@ h4 {
 }
 
 .connection-delete-button {
-  display: inline-grid;
   width: 26px;
   height: 26px;
-  place-items: center;
   color: var(--danger);
   background: var(--danger-soft);
   border: 1px solid rgba(239, 68, 68, 0.25);
   border-radius: 7px;
-  cursor: pointer;
   transition: all 0.2s;
 }
 


### PR DESCRIPTION
## Summary

- Add a focused `EditorIconButton` primitive for existing icon-only editor controls.
- Migrate topbar, project actions, connection, drawer toggle, and delete icon buttons to the shared primitive while preserving labels, titles, disabled state, and click behavior.
- Move shared icon-only layout declarations into `.editor-icon-button` while keeping per-control visual variants in place.
- Format the previously failing test files so the full repository format check now passes.

## Linked issue

Closes #47

## Verification

Automated:

- [x] `pnpm test` - passed, 8 files / 73 tests.
- [x] `pnpm lint` - passed.
- [x] `pnpm build` - passed.
- [x] `pnpm format:check` - passed.

Manual:

- [x] Opened the editor and confirmed topbar icon buttons render with disabled future actions.
- [x] Opened the project actions menu from the three-dot button.
- [x] Started and canceled a primitive-node connection from Tensor.
- [x] Created a Tensor -> Neuron connection and confirmed the connections drawer appears.
- [x] Collapsed and expanded the connections drawer and confirmed `aria-expanded` changed.
- [x] Deleted the Tensor -> Neuron connection and confirmed the drawer disappeared.

## Screenshots / video

A browser screenshot was captured in the Codex thread during manual verification after the UI smoke check.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

Review focus: this is intended to be a behavior-preserving cleanup. The new primitive owns button structure/accessibility defaults; existing CSS classes still own the visual variants.