### PR TITLE
[Roadmap]: Playwright functional regression suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,16 @@ jobs:
       - name: Run Playwright functional regression
         run: pnpm test:e2e
 
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-failure-artifacts
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,11 @@ jobs:
       - name: Check coverage
         run: pnpm test:coverage
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright functional regression
+        run: pnpm test:e2e
+
       - name: Build
         run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 coverage/
+playwright-report/
+test-results/
 .pnpm-store/
 .playwright-cli/
 output/playwright/

--- a/docs/roadmap/roadmap-process.md
+++ b/docs/roadmap/roadmap-process.md
@@ -237,7 +237,7 @@ Do not start PyTorch execution or training until the graph representation is min
 
 ## Required CI Checks
 
-Pull requests and pushes to `main` run the base CI workflow. The base workflow is limited to repository-owned commands so required checks stay auditable and reproducible within this repository:
+Pull requests and pushes to `main` run the repository CI workflow. The workflow is limited to repository-owned commands so required checks stay auditable and reproducible within this repository:
 
 ```bash
 pnpm install --frozen-lockfile
@@ -245,14 +245,17 @@ pnpm format:check
 pnpm lint
 pnpm test
 pnpm test:coverage
+pnpm test:e2e
 pnpm build
 ```
 
 Agents should run the same commands locally before opening pull requests when the issue touches code, build configuration, tests, or documentation.
 
-Coverage thresholds in the base workflow are a modest initial regression floor, not the final quality target for the product.
+Coverage thresholds are a modest initial regression floor, not the final quality target for the product.
 
-Playwright smoke checks, custom pull request metadata validation, and GitHub Project automation are separate roadmap issues and must not be hidden in the base CI pull request.
+`pnpm test:e2e` runs the Playwright functional regression suite for the current core editor surface. It covers editor load, node selection, inspector updates, primitive parameter editing, valid and invalid connection behavior, connection panel behavior, connection deletion, and stable project file export/reset/import behavior when browser automation supports it. It is not visual snapshot testing, cross-browser coverage, Tauri desktop automation, or exhaustive future Phase 2 workflow coverage.
+
+Custom pull request metadata validation and GitHub Project automation are separate roadmap issues and must not be hidden in the Playwright regression pull request.
 
 ## Later Automation
 

--- a/docs/roadmap/roadmap-process.md
+++ b/docs/roadmap/roadmap-process.md
@@ -253,7 +253,7 @@ Agents should run the same commands locally before opening pull requests when th
 
 Coverage thresholds are a modest initial regression floor, not the final quality target for the product.
 
-`pnpm test:e2e` runs the Playwright functional regression suite for the current core editor surface. It covers editor load, node selection, inspector updates, primitive parameter editing, valid and invalid connection behavior, connection panel behavior, connection deletion, and stable project file export/reset/import behavior when browser automation supports it. It is not visual snapshot testing, cross-browser coverage, Tauri desktop automation, or exhaustive future Phase 2 workflow coverage.
+`pnpm test:e2e` runs the Playwright functional regression suite for the current core editor surface. It covers editor load, node selection, inspector updates, primitive parameter editing, valid and invalid connection behavior, connection panel behavior, connection deletion, and stable project file export/reset/import behavior. It is not visual snapshot testing, cross-browser coverage, Tauri desktop automation, or exhaustive future Phase 2 workflow coverage.
 
 Custom pull request metadata validation and GitHub Project automation are separate roadmap issues and must not be hidden in the Playwright regression pull request.
 

--- a/docs/superpowers/plans/2026-05-09-playwright-functional-regression.md
+++ b/docs/superpowers/plans/2026-05-09-playwright-functional-regression.md
@@ -1,0 +1,822 @@
+# Playwright Functional Regression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Playwright functional regression suite for the current core editor workflows and run it in CI.
+
+**Architecture:** Add Playwright as a root-level test harness that starts the existing Vite dev server and runs one Chromium project against the real app. Keep e2e-only helpers under `tests/e2e/`, use accessible selectors first, and add only testability attributes to React Flow handles where the current UI has no stable accessible target. CI remains thin: install dependencies, install Playwright browsers, then call repository-owned scripts.
+
+**Tech Stack:** Playwright, Vite, React, React Flow, TypeScript, GitHub Actions, pnpm 10.27.0.
+
+---
+
+## File Structure
+
+- Modify `package.json`: add `test:e2e` script and `@playwright/test` dev dependency.
+- Modify `pnpm-lock.yaml`: update through `pnpm add -D @playwright/test`.
+- Create `playwright.config.ts`: configure Chromium, Vite `webServer`, artifacts, and base URL.
+- Modify `.gitignore`: ignore Playwright reports and test result artifacts.
+- Modify `src/App.tsx`: add `data-testid` attributes to React Flow handles only, so self-connection validation can be tested without brittle generated class selectors.
+- Create `tests/e2e/editor-core.spec.ts`: cover editor load, selection, inspector, parameter editing, connections, invalid connections, panel behavior, deletion, and export/reset/import.
+- Modify `.github/workflows/ci.yml`: install Playwright Chromium dependencies and run `pnpm test:e2e` after coverage and before build.
+- Modify `docs/roadmap/roadmap-process.md`: replace the old deferred Playwright note with required functional regression check documentation.
+
+## Execution Prerequisite
+
+Issue #55 is confirmed by the product owner, the live issue title/body have been updated, and the Project status is `In Progress`. Work must remain on `codex/55-playwright-functional-regression`.
+
+Run this before implementation:
+
+```bash
+git status --short --branch
+gh project item-list 5 --owner DoMo-98 --format json --limit 100 --jq '.items[] | select(.content.number == 55) | {status, title}'
+```
+
+Expected: branch is `codex/55-playwright-functional-regression`, no unstaged implementation changes, and #55 status is `In Progress`.
+
+### Task 1: Add Playwright Dependency And Config
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `pnpm-lock.yaml`
+- Create: `playwright.config.ts`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Confirm Playwright is not configured yet**
+
+Run:
+
+```bash
+pnpm test:e2e
+test ! -e playwright.config.ts
+```
+
+Expected: `pnpm test:e2e` fails because the script is missing, and `test ! -e playwright.config.ts` passes with no output.
+
+- [ ] **Step 2: Add Playwright**
+
+Run:
+
+```bash
+pnpm add -D @playwright/test
+```
+
+Expected: `package.json` and `pnpm-lock.yaml` change, and `@playwright/test` appears in `devDependencies`.
+
+- [ ] **Step 3: Add the package script**
+
+Update the `scripts` block in `package.json` to include `test:e2e` immediately after `test:coverage`:
+
+```json
+"scripts": {
+  "dev": "vite",
+  "tauri": "tauri",
+  "build": "tsc --noEmit && vite build",
+  "test": "vitest run",
+  "test:coverage": "vitest run --coverage",
+  "test:e2e": "playwright test",
+  "validate:commit-message": "node scripts/validate-commit-message.mjs",
+  "validate:roadmap-issue": "node scripts/validate-roadmap-issue.mjs",
+  "lint": "eslint .",
+  "format:check": "prettier --check ."
+}
+```
+
+- [ ] **Step 4: Create Playwright config**
+
+Create `playwright.config.ts`:
+
+```ts
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["line"], ["html", { open: "never" }]] : "list",
+  outputDir: "test-results",
+  use: {
+    baseURL: "http://127.0.0.1:1420",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    acceptDownloads: true,
+  },
+  webServer: {
+    command: "pnpm dev --host 127.0.0.1",
+    url: "http://127.0.0.1:1420",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});
+```
+
+Expected: Playwright uses the existing Vite port `1420` and keeps one Chromium project.
+
+- [ ] **Step 5: Ignore Playwright artifacts**
+
+Update `.gitignore` so the artifact block includes:
+
+```gitignore
+node_modules/
+dist/
+coverage/
+playwright-report/
+test-results/
+.pnpm-store/
+.playwright-cli/
+output/playwright/
+```
+
+Expected: Playwright reports and trace/video output are not tracked.
+
+- [ ] **Step 6: Run the empty Playwright suite**
+
+Run:
+
+```bash
+pnpm exec playwright install chromium
+pnpm test:e2e
+```
+
+Expected: browser install succeeds. `pnpm test:e2e` fails with a clear "No tests found" style message because no e2e specs exist yet.
+
+- [ ] **Step 7: Commit Playwright setup**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --message "test: add playwright e2e harness"
+git add package.json pnpm-lock.yaml playwright.config.ts .gitignore
+git commit -m "test: add playwright e2e harness"
+```
+
+Expected: commit succeeds.
+
+### Task 2: Add Stable E2E Testability For React Flow Handles
+
+**Files:**
+
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Add handle test ids**
+
+In `PrimitiveNodeCard`, update the target and source handles to include node-specific test ids:
+
+```tsx
+<Handle
+  type="target"
+  position={Position.Left}
+  className="architecture-node-handle"
+  data-testid={`node-${data.id}-target-handle`}
+/>
+```
+
+```tsx
+<Handle
+  type="source"
+  position={Position.Right}
+  className="architecture-node-handle"
+  data-testid={`node-${data.id}-source-handle`}
+/>
+```
+
+Expected: only testability attributes change; no user-facing behavior changes.
+
+- [ ] **Step 2: Run unit tests**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS. Existing React Flow and component tests still pass.
+
+- [ ] **Step 3: Run build**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: PASS. TypeScript accepts the added `data-testid` props on `Handle`.
+
+- [ ] **Step 4: Commit handle testability**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --message "test: expose stable graph handle selectors"
+git add src/App.tsx
+git commit -m "test: expose stable graph handle selectors"
+```
+
+Expected: commit succeeds.
+
+### Task 3: Add Core Editor Playwright Helpers And Load/Selection Tests
+
+**Files:**
+
+- Create: `tests/e2e/editor-core.spec.ts`
+
+- [ ] **Step 1: Create the e2e spec with helpers and first tests**
+
+Create `tests/e2e/editor-core.spec.ts`:
+
+```ts
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+async function selectNode(page: Page, name: RegExp) {
+  const node = page.getByRole("button", { name });
+  await node.click();
+  await expect(node).toHaveAttribute("aria-pressed", "true");
+  return node;
+}
+
+async function startConnection(page: Page, sourceLabel: string) {
+  await page
+    .getByRole("button", {
+      name: new RegExp(`start connection from ${sourceLabel}`, "i"),
+    })
+    .click();
+}
+
+async function completeConnection(
+  page: Page,
+  sourceLabel: string,
+  targetLabel: string,
+) {
+  await page
+    .getByRole("button", {
+      name: new RegExp(`connect ${sourceLabel} to ${targetLabel}`, "i"),
+    })
+    .click();
+}
+
+async function expectToast(page: Page, message: RegExp) {
+  await expect(
+    page.getByRole("alert").or(page.getByRole("status")),
+  ).toContainText(message);
+}
+
+async function dragHandleToHandle(
+  source: Locator,
+  target: Locator,
+  page: Page,
+) {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+
+  expect(sourceBox).not.toBeNull();
+  expect(targetBox).not.toBeNull();
+
+  if (!sourceBox || !targetBox) {
+    throw new Error("Graph handles must be visible before dragging.");
+  }
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width / 2,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    {
+      steps: 8,
+    },
+  );
+  await page.mouse.up();
+}
+
+test.describe("editor core functional regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("loads the editor workspace and default graph", async ({ page }) => {
+    await expect(page.getByText("dl-graph-studio")).toBeVisible();
+    await expect(page.getByRole("main", { name: /workspace/i })).toBeVisible();
+    await expect(
+      page.getByRole("region", { name: /graph canvas/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("complementary", { name: /node inspector/i }),
+    ).toBeVisible();
+    await expect(page.getByText("No node selected")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /tensor primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /neuron primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /activation primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /dense \/ linear primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /dense block composite node/i }),
+    ).toBeVisible();
+  });
+
+  test("selects primitive and composite nodes and updates the inspector", async ({
+    page,
+  }) => {
+    await selectNode(page, /neuron primitive node/i);
+
+    const inspector = page.getByRole("complementary", {
+      name: /node inspector/i,
+    });
+    await expect(
+      inspector.getByRole("heading", { name: "Neuron" }),
+    ).toBeVisible();
+    await expect(inspector.getByText("Foundation")).toBeVisible();
+    await expect(
+      inspector.getByRole("spinbutton", { name: /units/i }),
+    ).toHaveValue("1");
+    await expect(
+      inspector.getByRole("checkbox", { name: /bias/i }),
+    ).toBeChecked();
+
+    await selectNode(page, /dense block composite node/i);
+
+    await expect(
+      inspector.getByRole("heading", { name: "Dense Block" }),
+    ).toBeVisible();
+    await expect(inspector.getByText("Composite")).toBeVisible();
+    await expect(
+      inspector.getByText("Members: Neuron, Activation, Dense / Linear"),
+    ).toBeVisible();
+  });
+});
+```
+
+Expected: helpers are local to the spec and the first two tests cover load and selection/inspector.
+
+- [ ] **Step 2: Run Playwright tests**
+
+Run:
+
+```bash
+pnpm test:e2e
+```
+
+Expected: PASS. If role lookup for React Flow nodes fails, inspect the trace and use existing `data-testid` only for the affected node card lookup while preserving user-visible assertions.
+
+- [ ] **Step 3: Commit load and selection coverage**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --message "test: cover editor load and selection e2e"
+git add tests/e2e/editor-core.spec.ts
+git commit -m "test: cover editor load and selection e2e"
+```
+
+Expected: commit succeeds.
+
+### Task 4: Add Parameter Editing And Connection Flow Tests
+
+**Files:**
+
+- Modify: `tests/e2e/editor-core.spec.ts`
+
+- [ ] **Step 1: Add parameter editing test**
+
+Append this test inside the existing `test.describe` block:
+
+```ts
+test("edits primitive parameters and keeps values tied to the selected node", async ({
+  page,
+}) => {
+  await selectNode(page, /dense \/ linear primitive node/i);
+
+  const inspector = page.getByRole("complementary", {
+    name: /node inspector/i,
+  });
+  await inspector.getByRole("spinbutton", { name: /units/i }).fill("384");
+  await expect(
+    inspector.getByRole("spinbutton", { name: /units/i }),
+  ).toHaveValue("384");
+
+  await selectNode(page, /neuron primitive node/i);
+  await expect(
+    inspector.getByRole("spinbutton", { name: /units/i }),
+  ).toHaveValue("1");
+
+  await selectNode(page, /dense \/ linear primitive node/i);
+  await expect(
+    inspector.getByRole("spinbutton", { name: /units/i }),
+  ).toHaveValue("384");
+});
+```
+
+- [ ] **Step 2: Add valid connection and panel behavior test**
+
+Append this test inside the existing `test.describe` block:
+
+```ts
+test("creates a valid connection and toggles the connections panel", async ({
+  page,
+}) => {
+  await startConnection(page, "Tensor");
+  await completeConnection(page, "Tensor", "Neuron");
+
+  const connectionsPanel = page.getByRole("region", {
+    name: /graph connections/i,
+  });
+  await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
+  await expect(connectionsPanel.getByText("1")).toBeVisible();
+
+  await page
+    .getByRole("button", { name: /collapse connections panel/i })
+    .click();
+  await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeHidden();
+
+  await page.getByRole("button", { name: /expand connections panel/i }).click();
+  await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
+});
+```
+
+- [ ] **Step 3: Add connection deletion test**
+
+Append this test inside the existing `test.describe` block:
+
+```ts
+test("deletes one connection without clearing the remaining editor state", async ({
+  page,
+}) => {
+  await startConnection(page, "Tensor");
+  await completeConnection(page, "Tensor", "Neuron");
+  await startConnection(page, "Neuron");
+  await completeConnection(page, "Neuron", "Activation");
+
+  const connectionsPanel = page.getByRole("region", {
+    name: /graph connections/i,
+  });
+  await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
+  await expect(
+    connectionsPanel.getByText("Neuron -> Activation"),
+  ).toBeVisible();
+
+  await page
+    .getByRole("button", { name: /delete connection tensor to neuron/i })
+    .click();
+
+  await expect(page.getByRole("status")).toContainText(
+    /tensor -> neuron deleted/i,
+  );
+  await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeHidden();
+  await expect(
+    connectionsPanel.getByText("Neuron -> Activation"),
+  ).toBeVisible();
+
+  await selectNode(page, /activation primitive node/i);
+  await expect(
+    page
+      .getByRole("complementary", { name: /node inspector/i })
+      .getByRole("heading", { name: "Activation" }),
+  ).toBeVisible();
+});
+```
+
+- [ ] **Step 4: Run Playwright tests**
+
+Run:
+
+```bash
+pnpm test:e2e
+```
+
+Expected: PASS. The suite now covers parameter editing, valid connection creation, panel toggle, and deletion.
+
+- [ ] **Step 5: Commit editor interaction coverage**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --message "test: cover editor interactions e2e"
+git add tests/e2e/editor-core.spec.ts
+git commit -m "test: cover editor interactions e2e"
+```
+
+Expected: commit succeeds.
+
+### Task 5: Add Invalid Connection And Project File Workflow Tests
+
+**Files:**
+
+- Modify: `tests/e2e/editor-core.spec.ts`
+
+- [ ] **Step 1: Add invalid connection tests**
+
+Append these tests inside the existing `test.describe` block:
+
+```ts
+test("rejects duplicate and input-target connections with feedback", async ({
+  page,
+}) => {
+  await startConnection(page, "Tensor");
+  await completeConnection(page, "Tensor", "Neuron");
+  await startConnection(page, "Tensor");
+  await completeConnection(page, "Tensor", "Neuron");
+
+  await expectToast(page, /that connection already exists/i);
+
+  await startConnection(page, "Neuron");
+  await completeConnection(page, "Neuron", "Tensor");
+
+  await expectToast(
+    page,
+    /tensor is an input node and cannot receive connections/i,
+  );
+});
+
+test("rejects self-connections created through graph handles", async ({
+  page,
+}) => {
+  await dragHandleToHandle(
+    page.getByTestId("node-neuron-source-handle"),
+    page.getByTestId("node-neuron-target-handle"),
+    page,
+  );
+
+  await expectToast(page, /neuron cannot connect to itself/i);
+});
+```
+
+Expected: duplicate and input-target checks use accessible connection buttons. Self-connection uses explicit handle test ids because the current visible button workflow intentionally turns the source node button into a cancel action.
+
+- [ ] **Step 2: Add export/reset/import test**
+
+Append this test inside the existing `test.describe` block:
+
+```ts
+test("exports, resets, and imports the current project", async ({
+  page,
+}, testInfo) => {
+  await selectNode(page, /tensor primitive node/i);
+  await page.getByRole("textbox", { name: /shape/i }).fill("batch, features");
+  await selectNode(page, /neuron primitive node/i);
+  await page.getByRole("checkbox", { name: /bias/i }).uncheck();
+  await startConnection(page, "Tensor");
+  await completeConnection(page, "Tensor", "Neuron");
+
+  await page.getByRole("button", { name: /project actions/i }).click();
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("menuitem", { name: /export project/i }).click();
+  const download = await downloadPromise;
+  const exportedPath = testInfo.outputPath("exported-project.json");
+  await download.saveAs(exportedPath);
+  await expect(page.getByRole("status")).toContainText(/project exported/i);
+
+  await page.getByRole("button", { name: /project actions/i }).click();
+  await page.getByRole("menuitem", { name: /reset project/i }).click();
+  await expect(page.getByRole("status")).toContainText(/project reset/i);
+  await expect(
+    page.getByRole("region", { name: /graph connections/i }),
+  ).toBeHidden();
+
+  await selectNode(page, /dense \/ linear primitive node/i);
+  await expect(page.getByRole("spinbutton", { name: /units/i })).toHaveValue(
+    "128",
+  );
+
+  await page.getByLabel("Import project file").setInputFiles(exportedPath);
+
+  await expect(page.getByRole("status")).toContainText(/project imported/i);
+  await selectNode(page, /tensor primitive node/i);
+  await expect(page.getByRole("textbox", { name: /shape/i })).toHaveValue(
+    "batch, features",
+  );
+  await selectNode(page, /neuron primitive node/i);
+  await expect(page.getByRole("checkbox", { name: /bias/i })).not.toBeChecked();
+  await expect(
+    page
+      .getByRole("region", { name: /graph connections/i })
+      .getByText("Tensor -> Neuron"),
+  ).toBeVisible();
+});
+```
+
+Expected: export/reset/import is included in the required suite if this test passes locally and in CI.
+
+- [ ] **Step 3: Run Playwright tests**
+
+Run:
+
+```bash
+pnpm test:e2e
+```
+
+Expected: PASS.
+
+If only the export/reset/import test fails because Playwright cannot reliably use download or hidden file input behavior in this app, remove that test from the mandatory suite and add this note to the documentation task:
+
+```markdown
+Project export/reset/import remains covered by Vitest in `src/App.test.tsx` and `src/useProjectFileWorkflow.test.tsx`. A Playwright browser-level flow was attempted in #55 but was not kept as a required CI assertion because the Playwright download or file-upload path could not be made deterministic in local and CI verification without brittle browser workarounds. The PR notes include the failing command and observed error.
+```
+
+Do not remove the invalid connection tests unless the user approves a scope change.
+
+- [ ] **Step 4: Commit invalid and project workflow coverage**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --message "test: cover editor regression flows e2e"
+git add tests/e2e/editor-core.spec.ts
+git commit -m "test: cover editor regression flows e2e"
+```
+
+Expected: commit succeeds.
+
+### Task 6: Add Playwright To CI
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Update the workflow**
+
+In `.github/workflows/ci.yml`, insert these steps after `Check coverage` and before `Build`:
+
+```yaml
+- name: Install Playwright browsers
+  run: pnpm exec playwright install --with-deps chromium
+
+- name: Run Playwright functional regression
+  run: pnpm test:e2e
+```
+
+Expected: CI installs only Chromium and runs the repository-owned `test:e2e` script.
+
+- [ ] **Step 2: Run local workflow commands in issue order**
+
+Run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm format:check
+pnpm lint
+pnpm test
+pnpm test:coverage
+pnpm test:e2e
+pnpm build
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 3: Commit CI integration**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --message "test: run playwright regression in ci"
+git add .github/workflows/ci.yml
+git commit -m "test: run playwright regression in ci"
+```
+
+Expected: commit succeeds.
+
+### Task 7: Document The Functional Regression Gate
+
+**Files:**
+
+- Modify: `docs/roadmap/roadmap-process.md`
+
+- [ ] **Step 1: Update required CI check documentation**
+
+Replace the `## Required CI Checks` section with:
+
+````markdown
+## Required CI Checks
+
+Pull requests and pushes to `main` run the repository CI workflow. The workflow is limited to repository-owned commands so required checks stay auditable and reproducible within this repository:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm format:check
+pnpm lint
+pnpm test
+pnpm test:coverage
+pnpm test:e2e
+pnpm build
+```
+````
+
+Agents should run the same commands locally before opening pull requests when the issue touches code, build configuration, tests, or documentation.
+
+Coverage thresholds are a modest initial regression floor, not the final quality target for the product.
+
+`pnpm test:e2e` runs the Playwright functional regression suite for the current core editor surface. It covers editor load, node selection, inspector updates, primitive parameter editing, valid and invalid connection behavior, connection panel behavior, connection deletion, and stable project file export/reset/import behavior when browser automation supports it. It is not visual snapshot testing, cross-browser coverage, Tauri desktop automation, or exhaustive future Phase 2 workflow coverage.
+
+Custom pull request metadata validation and GitHub Project automation are separate roadmap issues and must not be hidden in the Playwright regression pull request.
+
+````
+
+Expected: docs no longer describe Playwright as only a deferred smoke check.
+
+- [ ] **Step 2: Run documentation format check**
+
+Run:
+
+```bash
+pnpm format:check
+````
+
+Expected: PASS. If Prettier reports Markdown formatting, run:
+
+```bash
+pnpm exec prettier --write docs/roadmap/roadmap-process.md docs/superpowers/plans/2026-05-09-playwright-functional-regression.md
+pnpm format:check
+```
+
+- [ ] **Step 3: Commit documentation**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --message "docs: document playwright regression gate"
+git add docs/roadmap/roadmap-process.md docs/superpowers/plans/2026-05-09-playwright-functional-regression.md
+git commit -m "docs: document playwright regression gate"
+```
+
+Expected: commit succeeds.
+
+### Task 8: Final Verification And PR Preparation
+
+**Files:**
+
+- Verify all changed files.
+
+- [ ] **Step 1: Run full automated verification**
+
+Run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm format:check
+pnpm lint
+pnpm test
+pnpm test:coverage
+pnpm test:e2e
+pnpm build
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 2: Review diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main..HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: only #55 design, Playwright setup, e2e tests, CI, and roadmap docs changed.
+
+- [ ] **Step 3: Prepare manual verification instructions**
+
+Use these manual verification steps in the final update and PR:
+
+```markdown
+Manual verification:
+
+1. Run `pnpm test:e2e`.
+2. Confirm Playwright opens the Vite app and passes the editor functional regression suite.
+3. Confirm the suite covers editor load, node selection, inspector updates, parameter editing, valid connections, invalid/duplicate connection feedback, connection panel behavior, deletion, and export/reset/import if retained.
+4. Open the GitHub Actions run for the PR and confirm the Playwright functional regression step is visible and passes.
+5. If a Playwright run fails, open the uploaded trace or screenshot artifact and confirm it identifies the broken editor flow.
+```
+
+- [ ] **Step 4: Validate commit messages**
+
+Run:
+
+```bash
+pnpm validate:commit-message -- --range origin/main..HEAD
+```
+
+Expected: PASS. Every commit on the branch uses the allowed Conventional Commit subset.
+
+## Self-Review
+
+- Spec coverage: Tasks cover Playwright installation, `test:e2e`, Vite `webServer`, Chromium CI, editor load, node selection, inspector updates, parameter editing, valid connections, self/duplicate/data-target invalid feedback, panel toggle, deletion, export/reset/import with a documented fallback, artifacts, documentation, and issue-required verification.
+- Placeholder scan: No `TBD`, `TODO`, "implement later", or undefined follow-up instructions remain. The only conditional path is export/reset/import instability, with a concrete required note.
+- Type and selector consistency: Test helpers use Playwright `Page` and `Locator`, existing accessible names from `src/App.tsx`, and new handle test ids added in Task 2.

--- a/docs/superpowers/specs/2026-05-09-playwright-functional-regression-design.md
+++ b/docs/superpowers/specs/2026-05-09-playwright-functional-regression-design.md
@@ -1,0 +1,182 @@
+# Playwright Functional Regression Design
+
+## Context
+
+Issue #55 originally described a narrow Playwright smoke check for the Vite
+editor. In the planning thread for #55, the product owner approved expanding
+that issue on 2026-05-09 so the pull request covers a functional Playwright
+regression suite for the core capabilities currently available in the app. The
+live issue must record this scope change before implementation begins.
+
+The repository already has the base CI workflow from #54. CI runs dependency
+installation, formatting, linting, Vitest tests, Vitest coverage, and build
+checks. The app is a Vite, React, TypeScript editor using React Flow for the
+canvas. Existing Vitest coverage exercises editor state and project-file logic,
+but there is no browser-level Playwright coverage yet.
+
+## Goal
+
+Add Playwright as a functional regression gate for the current Phase 1 editor
+surface. The suite should verify that the real app boots in a browser and that
+the main user-facing editor capabilities still work together.
+
+This issue is no longer a minimum smoke-test issue. It should remain bounded
+and reviewable, but it should cover the core functionality that exists today:
+editor load, node selection, inspector behavior, parameter editing, valid and
+invalid connections, connection panel behavior, connection deletion, and stable
+project file workflows when practical.
+
+## Scope
+
+- Install and configure Playwright for the Vite app.
+- Add a `pnpm test:e2e` script.
+- Configure Playwright to start the Vite dev server for local and CI runs.
+- Add Chromium Playwright coverage for the editor's core functional flows.
+- Run the Playwright suite in CI after the build-independent quality checks.
+- Preserve useful failure artifacts, including traces and screenshots.
+- Document the local command, CI gate, coverage intent, and known limits.
+- Update issue #55 so its live roadmap scope matches this approved design.
+
+## Functional Coverage
+
+The Playwright suite should cover these flows:
+
+- Editor load: the workspace, graph canvas, primitive nodes, composite node, and
+  empty inspector state render.
+- Node selection: a primitive node and the composite node can be selected, and
+  the inspector updates to the selected node.
+- Inspector editing: editable primitive parameters can be changed and remain
+  associated with the correct node while switching between nodes.
+- Valid connections: a valid connection such as `Tensor -> Neuron` can be
+  created and appears in the graph connections panel.
+- Invalid connections: self-connections, duplicate connections, and connections
+  into the input `Tensor` node are rejected with visible feedback.
+- Connection panel: the panel can be expanded and collapsed when connections
+  exist.
+- Connection deletion: a created connection can be removed without breaking the
+  remaining editor state.
+- Project file workflows: export, reset, and import should be attempted with
+  Playwright's download and file-upload APIs. They may be omitted from the
+  required Playwright pass only if a concrete browser or CI limitation makes the
+  flow unreliable after implementation attempts; the PR must document the error,
+  the skipped assertion, and the existing Vitest fallback coverage.
+
+## Test Architecture
+
+Use a standard `playwright.config.ts` at the repository root. The config should
+start the Vite dev server through Playwright `webServer`, reuse the server when
+appropriate, and run against Chromium first for reliability. Cross-browser
+matrices are intentionally out of scope unless a concrete bug requires them.
+
+Place tests under a focused e2e directory such as `tests/e2e/`. Keep helpers
+small and local to the Playwright tests. Good helper boundaries include:
+
+- selecting an editor node by accessible name,
+- starting or completing a connection,
+- asserting visible toast or validation feedback,
+- opening project actions,
+- creating or uploading a project fixture if import/export is stable.
+
+Tests should prefer accessible roles, labels, and user-visible text over
+implementation-specific CSS selectors. `data-testid` may be used only where the
+existing UI has no stable accessible surface or where React Flow rendering makes
+accessible lookup impractical.
+
+## CI Behavior
+
+The CI workflow should install Playwright browsers and run `pnpm test:e2e` after
+formatting, linting, Vitest tests, and Vitest coverage. `pnpm build` should run
+after Playwright, matching the repository's current verification order for this
+issue. The expected local and CI command set is:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm format:check
+pnpm lint
+pnpm test
+pnpm test:coverage
+pnpm test:e2e
+pnpm build
+```
+
+The Playwright step should fail the workflow when a core regression is detected
+and should retain enough artifacts to diagnose the failure without reproducing
+it locally first.
+
+## Error Handling
+
+Playwright failures should be actionable. Assertions should explain which user
+flow broke rather than only checking incidental DOM structure. Failure artifacts
+should include traces and screenshots on failure. Video can be enabled on
+failure if it does not make the workflow too noisy.
+
+If export, reset, and import cannot be automated reliably because of browser
+download or file-picker constraints after using Playwright's download and
+file-upload APIs, the implementation should:
+
+- keep the unstable project-file assertions out of the mandatory Playwright pass,
+- document the skipped browser-level coverage, error, and fallback in the
+  roadmap docs or PR notes,
+- rely on existing Vitest coverage for project-file behavior,
+- avoid adding brittle Playwright workarounds.
+
+## Out Of Scope
+
+- Visual snapshot testing.
+- Exhaustive coverage of every Phase 1 edge case.
+- Cross-browser Playwright matrices without a concrete need.
+- Tauri desktop automation.
+- Custom pull request or commit metadata validation.
+- Raising Vitest coverage thresholds.
+- GitHub Project automation.
+- New product behavior or UI redesign.
+
+## Acceptance Criteria
+
+- `pnpm test:e2e` runs the Playwright functional regression suite locally.
+- CI installs required Playwright browser dependencies and runs `pnpm test:e2e`.
+- The suite verifies editor load, node selection, inspector updates, and
+  primitive parameter editing.
+- The suite verifies valid connection creation and connection panel behavior.
+- The suite verifies self-connection feedback, duplicate-connection feedback,
+  and connection-into-`Tensor` feedback.
+- The suite verifies connection deletion.
+- Export, reset, and import are automated through Playwright download/upload APIs
+  when stable, or the concrete browser/CI limitation and Vitest fallback are
+  documented explicitly.
+- Playwright failure artifacts are preserved in CI.
+- Documentation explains the local command, CI gate, and intentionally bounded
+  scope.
+- Issue #55 reflects the approved expanded scope before implementation begins.
+
+## Verification
+
+Automated verification for the implementation should run:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm format:check
+pnpm lint
+pnpm test
+pnpm test:coverage
+pnpm test:e2e
+pnpm build
+```
+
+Manual verification should confirm:
+
+- a pull request or test branch Actions run includes a clearly named Playwright
+  step,
+- a passing run exercises the core editor flows listed above,
+- a failing run uploads useful Playwright artifacts,
+- documentation distinguishes the functional regression suite from visual,
+  cross-browser, Tauri, and future Phase 2 coverage.
+
+## Follow-Up Candidates
+
+Future roadmap issues can deepen coverage after this issue lands:
+
+- visual regression testing for canvas and inspector layout,
+- cross-browser Playwright coverage,
+- broader project-file workflow coverage if it is not stable in this issue,
+- Phase 2 reusable component workflows as those capabilities are built.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc --noEmit && vite build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "validate:commit-message": "node scripts/validate-commit-message.mjs",
     "validate:roadmap-issue": "node scripts/validate-roadmap-issue.mjs",
     "lint": "eslint .",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.0.0",
     "@tauri-apps/cli": "^2.0.0",
     "@testing-library/jest-dom": "^6.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [["line"], ["html", { open: "never" }]] : "list",
+  outputDir: "test-results",
+  use: {
+    baseURL: "http://127.0.0.1:1420",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    acceptDownloads: true,
+  },
+  webServer: {
+    command: "pnpm dev --host 127.0.0.1",
+    url: "http://127.0.0.1:1420",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       "@eslint/js":
         specifier: ^9.0.0
         version: 9.39.4
+      "@playwright/test":
+        specifier: ^1.59.1
+        version: 1.59.1
       "@tailwindcss/vite":
         specifier: ^4.0.0
         version: 4.2.4(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
@@ -719,6 +722,14 @@ packages:
         integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
       }
     engines: { node: ">=14" }
+
+  "@playwright/test@1.59.1":
+    resolution:
+      {
+        integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   "@radix-ui/primitive@1.1.3":
     resolution:
@@ -2527,6 +2538,14 @@ packages:
       }
     engines: { node: ">= 6" }
 
+  fsevents@2.3.2:
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution:
       {
@@ -3210,6 +3229,22 @@ packages:
         integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
+
+  playwright-core@1.59.1:
+    resolution:
+      {
+        integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution:
+      {
+        integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   postcss@8.5.12:
     resolution:
@@ -4220,6 +4255,10 @@ snapshots:
 
   "@pkgjs/parseargs@0.11.0":
     optional: true
+
+  "@playwright/test@1.59.1":
+    dependencies:
+      playwright: 1.59.1
 
   "@radix-ui/primitive@1.1.3": {}
 
@@ -5329,6 +5368,9 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5684,6 +5726,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.12:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -358,6 +358,7 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
         type="target"
         position={Position.Left}
         className="architecture-node-handle"
+        data-testid={`node-${data.id}-target-handle`}
       />
       <ArchitectureNodeCardSurface
         id={data.id}
@@ -398,6 +399,7 @@ function PrimitiveNodeCard({ data }: NodeProps<PrimitiveFlowNode>) {
         type="source"
         position={Position.Right}
         className="architecture-node-handle"
+        data-testid={`node-${data.id}-source-handle`}
       />
     </div>
   );

--- a/tests/e2e/editor-core.spec.ts
+++ b/tests/e2e/editor-core.spec.ts
@@ -1,0 +1,127 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+async function selectNode(page: Page, name: RegExp) {
+  const node = page.getByRole("button", { name });
+  await node.click();
+  await expect(node).toHaveAttribute("aria-pressed", "true");
+  return node;
+}
+
+async function startConnection(page: Page, sourceLabel: string) {
+  await page
+    .getByRole("button", {
+      name: new RegExp(`start connection from ${sourceLabel}`, "i"),
+    })
+    .click();
+}
+
+async function completeConnection(
+  page: Page,
+  sourceLabel: string,
+  targetLabel: string,
+) {
+  await page
+    .getByRole("button", {
+      name: new RegExp(`connect ${sourceLabel} to ${targetLabel}`, "i"),
+    })
+    .click();
+}
+
+async function expectToast(page: Page, message: RegExp) {
+  await expect(
+    page.getByRole("alert").or(page.getByRole("status")),
+  ).toContainText(message);
+}
+
+async function dragHandleToHandle(
+  source: Locator,
+  target: Locator,
+  page: Page,
+) {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+
+  expect(sourceBox).not.toBeNull();
+  expect(targetBox).not.toBeNull();
+
+  if (!sourceBox || !targetBox) {
+    throw new Error("Graph handles must be visible before dragging.");
+  }
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width / 2,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    {
+      steps: 8,
+    },
+  );
+  await page.mouse.up();
+}
+
+test.describe("editor core functional regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("loads the editor workspace and default graph", async ({ page }) => {
+    await expect(page.getByText("dl-graph-studio")).toBeVisible();
+    await expect(page.getByRole("main", { name: /workspace/i })).toBeVisible();
+    await expect(
+      page.getByRole("region", { name: /graph canvas/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("complementary", { name: /node inspector/i }),
+    ).toBeVisible();
+    await expect(page.getByText("No node selected")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /tensor primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /neuron primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /activation primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /dense \/ linear primitive node/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /dense block composite node/i }),
+    ).toBeVisible();
+  });
+
+  test("selects primitive and composite nodes and updates the inspector", async ({
+    page,
+  }) => {
+    await selectNode(page, /neuron primitive node/i);
+
+    const inspector = page.getByRole("complementary", {
+      name: /node inspector/i,
+    });
+    await expect(
+      inspector.getByRole("heading", { name: "Neuron" }),
+    ).toBeVisible();
+    await expect(inspector.getByText("Foundation")).toBeVisible();
+    await expect(
+      inspector.getByRole("spinbutton", { name: /units/i }),
+    ).toHaveValue("1");
+    await expect(
+      inspector.getByRole("checkbox", { name: /bias/i }),
+    ).toBeChecked();
+
+    await selectNode(page, /dense block composite node/i);
+
+    await expect(
+      inspector.getByRole("heading", { name: "Dense Block" }),
+    ).toBeVisible();
+    await expect(inspector.getByText("Composite")).toBeVisible();
+    await expect(
+      inspector.getByText("Members: Neuron, Activation, Dense / Linear"),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/editor-core.spec.ts
+++ b/tests/e2e/editor-core.spec.ts
@@ -123,9 +123,7 @@ test.describe("editor core functional regression", () => {
       name: /graph connections/i,
     });
     await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
-    await expect(
-      connectionsPanel.locator(".connection-drawer-summary span"),
-    ).toHaveText("1");
+    await expect(connectionsPanel.getByText(/^1$/)).toBeVisible();
 
     await page
       .getByRole("button", { name: /collapse connections panel/i })

--- a/tests/e2e/editor-core.spec.ts
+++ b/tests/e2e/editor-core.spec.ts
@@ -1,66 +1,10 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 async function selectNode(page: Page, name: RegExp) {
   const node = page.getByRole("button", { name });
   await node.click();
   await expect(node).toHaveAttribute("aria-pressed", "true");
   return node;
-}
-
-async function startConnection(page: Page, sourceLabel: string) {
-  await page
-    .getByRole("button", {
-      name: new RegExp(`start connection from ${sourceLabel}`, "i"),
-    })
-    .click();
-}
-
-async function completeConnection(
-  page: Page,
-  sourceLabel: string,
-  targetLabel: string,
-) {
-  await page
-    .getByRole("button", {
-      name: new RegExp(`connect ${sourceLabel} to ${targetLabel}`, "i"),
-    })
-    .click();
-}
-
-async function expectToast(page: Page, message: RegExp) {
-  await expect(
-    page.getByRole("alert").or(page.getByRole("status")),
-  ).toContainText(message);
-}
-
-async function dragHandleToHandle(
-  source: Locator,
-  target: Locator,
-  page: Page,
-) {
-  const sourceBox = await source.boundingBox();
-  const targetBox = await target.boundingBox();
-
-  expect(sourceBox).not.toBeNull();
-  expect(targetBox).not.toBeNull();
-
-  if (!sourceBox || !targetBox) {
-    throw new Error("Graph handles must be visible before dragging.");
-  }
-
-  await page.mouse.move(
-    sourceBox.x + sourceBox.width / 2,
-    sourceBox.y + sourceBox.height / 2,
-  );
-  await page.mouse.down();
-  await page.mouse.move(
-    targetBox.x + targetBox.width / 2,
-    targetBox.y + targetBox.height / 2,
-    {
-      steps: 8,
-    },
-  );
-  await page.mouse.up();
 }
 
 test.describe("editor core functional regression", () => {

--- a/tests/e2e/editor-core.spec.ts
+++ b/tests/e2e/editor-core.spec.ts
@@ -123,7 +123,9 @@ test.describe("editor core functional regression", () => {
       name: /graph connections/i,
     });
     await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
-    await expect(connectionsPanel.getByText("1")).toBeVisible();
+    await expect(
+      connectionsPanel.locator(".connection-drawer-summary span"),
+    ).toHaveText("1");
 
     await page
       .getByRole("button", { name: /collapse connections panel/i })

--- a/tests/e2e/editor-core.spec.ts
+++ b/tests/e2e/editor-core.spec.ts
@@ -7,6 +7,26 @@ async function selectNode(page: Page, name: RegExp) {
   return node;
 }
 
+async function startConnection(page: Page, sourceLabel: string) {
+  await page
+    .getByRole("button", {
+      name: new RegExp(`start connection from ${sourceLabel}`, "i"),
+    })
+    .click();
+}
+
+async function completeConnection(
+  page: Page,
+  sourceLabel: string,
+  targetLabel: string,
+) {
+  await page
+    .getByRole("button", {
+      name: new RegExp(`connect ${sourceLabel} to ${targetLabel}`, "i"),
+    })
+    .click();
+}
+
 test.describe("editor core functional regression", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
@@ -66,6 +86,89 @@ test.describe("editor core functional regression", () => {
     await expect(inspector.getByText("Composite")).toBeVisible();
     await expect(
       inspector.getByText("Members: Neuron, Activation, Dense / Linear"),
+    ).toBeVisible();
+  });
+
+  test("edits primitive parameters and keeps values tied to the selected node", async ({
+    page,
+  }) => {
+    await selectNode(page, /dense \/ linear primitive node/i);
+
+    const inspector = page.getByRole("complementary", {
+      name: /node inspector/i,
+    });
+    await inspector.getByRole("spinbutton", { name: /units/i }).fill("384");
+    await expect(
+      inspector.getByRole("spinbutton", { name: /units/i }),
+    ).toHaveValue("384");
+
+    await selectNode(page, /neuron primitive node/i);
+    await expect(
+      inspector.getByRole("spinbutton", { name: /units/i }),
+    ).toHaveValue("1");
+
+    await selectNode(page, /dense \/ linear primitive node/i);
+    await expect(
+      inspector.getByRole("spinbutton", { name: /units/i }),
+    ).toHaveValue("384");
+  });
+
+  test("creates a valid connection and toggles the connections panel", async ({
+    page,
+  }) => {
+    await startConnection(page, "Tensor");
+    await completeConnection(page, "Tensor", "Neuron");
+
+    const connectionsPanel = page.getByRole("region", {
+      name: /graph connections/i,
+    });
+    await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
+    await expect(connectionsPanel.getByText("1")).toBeVisible();
+
+    await page
+      .getByRole("button", { name: /collapse connections panel/i })
+      .click();
+    await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeHidden();
+
+    await page
+      .getByRole("button", { name: /expand connections panel/i })
+      .click();
+    await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
+  });
+
+  test("deletes one connection without clearing the remaining editor state", async ({
+    page,
+  }) => {
+    await startConnection(page, "Tensor");
+    await completeConnection(page, "Tensor", "Neuron");
+    await startConnection(page, "Neuron");
+    await completeConnection(page, "Neuron", "Activation");
+
+    const connectionsPanel = page.getByRole("region", {
+      name: /graph connections/i,
+    });
+    await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeVisible();
+    await expect(
+      connectionsPanel.getByText("Neuron -> Activation"),
+    ).toBeVisible();
+
+    await page
+      .getByRole("button", { name: /delete connection tensor to neuron/i })
+      .click();
+
+    await expect(page.getByRole("status")).toContainText(
+      /tensor -> neuron deleted/i,
+    );
+    await expect(connectionsPanel.getByText("Tensor -> Neuron")).toBeHidden();
+    await expect(
+      connectionsPanel.getByText("Neuron -> Activation"),
+    ).toBeVisible();
+
+    await selectNode(page, /activation primitive node/i);
+    await expect(
+      page
+        .getByRole("complementary", { name: /node inspector/i })
+        .getByRole("heading", { name: "Activation" }),
     ).toBeVisible();
   });
 });

--- a/tests/e2e/editor-core.spec.ts
+++ b/tests/e2e/editor-core.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 async function selectNode(page: Page, name: RegExp) {
   const node = page.getByRole("button", { name });
@@ -25,6 +25,42 @@ async function completeConnection(
       name: new RegExp(`connect ${sourceLabel} to ${targetLabel}`, "i"),
     })
     .click();
+}
+
+async function expectToast(page: Page, message: RegExp) {
+  await expect(
+    page.getByRole("alert").or(page.getByRole("status")),
+  ).toContainText(message);
+}
+
+async function dragHandleToHandle(
+  source: Locator,
+  target: Locator,
+  page: Page,
+) {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+
+  expect(sourceBox).not.toBeNull();
+  expect(targetBox).not.toBeNull();
+
+  if (!sourceBox || !targetBox) {
+    throw new Error("Graph handles must be visible before dragging.");
+  }
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width / 2,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    {
+      steps: 8,
+    },
+  );
+  await page.mouse.up();
 }
 
 test.describe("editor core functional regression", () => {
@@ -169,6 +205,85 @@ test.describe("editor core functional regression", () => {
       page
         .getByRole("complementary", { name: /node inspector/i })
         .getByRole("heading", { name: "Activation" }),
+    ).toBeVisible();
+  });
+
+  test("rejects duplicate and input-target connections with feedback", async ({
+    page,
+  }) => {
+    await startConnection(page, "Tensor");
+    await completeConnection(page, "Tensor", "Neuron");
+    await startConnection(page, "Tensor");
+    await completeConnection(page, "Tensor", "Neuron");
+
+    await expectToast(page, /that connection already exists/i);
+
+    await startConnection(page, "Neuron");
+    await completeConnection(page, "Neuron", "Tensor");
+
+    await expectToast(
+      page,
+      /tensor is an input node and cannot receive connections/i,
+    );
+  });
+
+  test("rejects self-connections created through graph handles", async ({
+    page,
+  }) => {
+    await dragHandleToHandle(
+      page.getByTestId("node-neuron-source-handle"),
+      page.getByTestId("node-neuron-target-handle"),
+      page,
+    );
+
+    await expectToast(page, /neuron cannot connect to itself/i);
+  });
+
+  test("exports, resets, and imports the current project", async ({
+    page,
+  }, testInfo) => {
+    await selectNode(page, /tensor primitive node/i);
+    await page.getByRole("textbox", { name: /shape/i }).fill("batch, features");
+    await selectNode(page, /neuron primitive node/i);
+    await page.getByRole("checkbox", { name: /bias/i }).uncheck();
+    await startConnection(page, "Tensor");
+    await completeConnection(page, "Tensor", "Neuron");
+
+    await page.getByRole("button", { name: /project actions/i }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("menuitem", { name: /export project/i }).click();
+    const download = await downloadPromise;
+    const exportedPath = testInfo.outputPath("exported-project.json");
+    await download.saveAs(exportedPath);
+    await expect(page.getByRole("status")).toContainText(/project exported/i);
+
+    await page.getByRole("button", { name: /project actions/i }).click();
+    await page.getByRole("menuitem", { name: /reset project/i }).click();
+    await expect(page.getByRole("status")).toContainText(/project reset/i);
+    await expect(
+      page.getByRole("region", { name: /graph connections/i }),
+    ).toBeHidden();
+
+    await selectNode(page, /dense \/ linear primitive node/i);
+    await expect(page.getByRole("spinbutton", { name: /units/i })).toHaveValue(
+      "128",
+    );
+
+    await page.getByLabel("Import project file").setInputFiles(exportedPath);
+
+    await expect(page.getByRole("status")).toContainText(/project imported/i);
+    await selectNode(page, /tensor primitive node/i);
+    await expect(page.getByRole("textbox", { name: /shape/i })).toHaveValue(
+      "batch, features",
+    );
+    await selectNode(page, /neuron primitive node/i);
+    await expect(
+      page.getByRole("checkbox", { name: /bias/i }),
+    ).not.toBeChecked();
+    await expect(
+      page
+        .getByRole("region", { name: /graph connections/i })
+        .getByText("Tensor -> Neuron"),
     ).toBeVisible();
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,13 @@ export default defineConfig({
   envPrefix: ["VITE_", "TAURI_"],
   test: {
     environment: "jsdom",
-    exclude: ["node_modules/**", "dist/**", ".pnpm-store/**", "src-tauri/**"],
+    exclude: [
+      "node_modules/**",
+      "dist/**",
+      ".pnpm-store/**",
+      "src-tauri/**",
+      "tests/e2e/**",
+    ],
     globals: true,
     setupFiles: "./src/test/setup.ts",
     coverage: {


### PR DESCRIPTION
## Summary

- Expanded #55 from a minimal smoke check into a Playwright functional regression suite for the current core editor workflows.
- Added Playwright configuration, Chromium e2e coverage, stable graph handle selectors, and CI execution with failure artifact upload.
- Updated roadmap/design docs so required CI checks document `pnpm test:e2e` and the functional regression scope.

## Linked issue

Closes #55

## Verification

Automated:

- [x] `CI=true pnpm install --frozen-lockfile` passed after network escalation.
- [x] `pnpm format:check` passed.
- [x] `pnpm lint` passed.
- [x] `pnpm test` passed: 9 files, 106 tests.
- [x] `pnpm test:coverage` passed with thresholds met.
- [x] `pnpm test:e2e` passed: 8 Playwright tests.
- [x] `pnpm build` passed.
- [x] `pnpm validate:commit-message -- --range origin/main..HEAD` passed.

Manual:

- [x] Ran `pnpm test:e2e` and confirmed the suite covers editor load, node selection, inspector updates, parameter editing, valid connections, invalid/duplicate connection feedback, connection panel behavior, deletion, and export/reset/import.
- [x] Confirmed the CI workflow includes a clearly named `Run Playwright functional regression` step.
- [x] Confirmed the CI workflow uploads `playwright-report/` and `test-results/` as `playwright-failure-artifacts` on failure.

## Screenshots / video

Not applicable. This PR adds test, CI, and documentation coverage only; it does not change user-visible UI behavior.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- Local `pnpm test:e2e` requires permission to bind the Vite dev server to `127.0.0.1:1420` in this sandboxed environment.
- Playwright is intentionally Chromium-only for this issue; visual snapshots, cross-browser coverage, and Tauri desktop automation remain out of scope.
