### PR TITLE
docs: add milestone project board focus workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository uses an agent-assisted roadmap workflow. Agents must work from e
 - `docs/superpowers/specs/2026-05-03-product-owner-idea-intake-design.md` defines the product-owner idea intake convention.
 - `docs/superpowers/specs/2026-05-03-start-task-in-progress-design.md` defines when a confirmed local task moves to `In Progress`.
 - `docs/superpowers/specs/2026-05-08-maintainability-scope-balance-design.md` defines how implementation work balances issue scope with maintainability and scalability.
+- `docs/superpowers/specs/2026-05-10-milestone-project-board-focus-design.md` defines the GitHub Project milestone focus field, active milestone view, global milestone overview, and milestone focus advancement convention.
 - The GitHub Project for this repository is `dl-graph-studio Roadmap`.
 - GitHub Issues and the GitHub Project are the operational source of truth for executable roadmap work.
 - Pull requests are delivery and review artifacts, not planning documents.
@@ -47,10 +48,25 @@ This repository uses an agent-assisted roadmap workflow. Agents must work from e
 - If the idea is a new roadmap task, draft a roadmap issue using `.github/ISSUE_TEMPLATE/roadmap-task.md`.
 - If the idea changes high-level product direction, treat it as a PRD or planning discussion before creating executable issues.
 - Ask focused clarifying questions until the issue has objective, scope, out-of-scope, acceptance criteria, verification, milestone, labels, and an expected PR size that fits the normal 15-30 minute review window.
+- Recommend a `Milestone Focus` value for each drafted roadmap issue: normally `Current` for active milestone work, `Next` for prepared next-milestone work, and `Later` for future milestone work.
 - If the idea is too large for one reviewable PR, propose a split and recommend the first issue to create.
 - Before creating or updating a live roadmap issue outside GitHub's issue-template UI, run `pnpm validate:roadmap-issue -- --title "[Roadmap]: <title>" --body <body-file>`.
 - Ask the product owner to confirm issue creation, readiness, priority, and intended Project status before applying `ready`, adding the issue to the `dl-graph-studio Roadmap` Project, or starting implementation.
 - When creating a roadmap issue, add it to the `dl-graph-studio Roadmap` Project in the confirmed status before treating the issue as ready for roadmap execution. If Project placement fails, ask the product owner for the permissions, authorization, or project metadata needed for the agent to complete the placement, or for explicit authorization to continue while the Project status remains temporarily unchanged, instead of asking for a manual Project update.
+
+## Milestone Project Board Focus
+
+- The `dl-graph-studio Roadmap` GitHub Project must use a single-select Project field named `Milestone Focus` with values `Current`, `Next`, `Later`, and `Closed`.
+- GitHub Milestones remain the canonical phase assignment for issues. `Milestone Focus` controls Project-board visibility and does not replace the issue milestone.
+- The Project should have an `Active Milestone` board view filtered to `Milestone Focus:Current` and grouped by the existing `Status` field.
+- The Project should have a `Milestone Overview` global view that shows all roadmap items with GitHub Milestone, `Milestone Focus`, `Status`, labels, and linked pull requests visible.
+- When creating or updating a roadmap issue, set both the issue's GitHub Milestone and the Project item's `Milestone Focus` value.
+- Use `Current` for the active milestone, `Next` for the next planned milestone, `Later` for future milestone work, and `Closed` for completed milestone work after closeout is accepted.
+- `Milestone Focus` must not change the executable task rule: an executable issue still requires Project status `Ready` and the `ready` label.
+- When every issue in the `Current` milestone is `Done`, first check that milestone UX/UI hardening and technical audit are `Done` or explicitly skipped, no milestone pull request remains open in review, and no blocking follow-up must be completed before closeout.
+- If closeout is complete, propose moving the completed milestone's Project items from `Current` to `Closed` and the next milestone's Project items from `Next` to `Current`. After product-owner confirmation, update the Project fields if tooling and permissions allow.
+- A milestone focus transition updates board focus only. It does not authorize implementation of the next roadmap issue.
+- If Project field updates fail because of permissions, missing tooling, unresolved Project metadata, GitHub availability, or another blocker, report the limitation and ask for the concrete access, authorization, or Project metadata needed to complete the update.
 
 ## Milestone UX/UI Hardening
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ This repository uses an agent-assisted roadmap workflow. Agents must work from e
 - When creating or updating a roadmap issue, set both the issue's GitHub Milestone and the Project item's `Milestone Focus` value.
 - Use `Current` for the active milestone, `Next` for the next planned milestone, `Later` for future milestone work, and `Closed` for completed milestone work after closeout is accepted.
 - `Milestone Focus` must not change the executable task rule: an executable issue still requires Project status `Ready` and the `ready` label.
-- When every issue in the `Current` milestone is `Done`, first check that milestone UX/UI hardening and technical audit are `Done` or explicitly skipped, no milestone pull request remains open in review, and no blocking follow-up must be completed before closeout.
-- If closeout is complete, propose moving the completed milestone's Project items from `Current` to `Closed` and the next milestone's Project items from `Next` to `Current`. After product-owner confirmation, update the Project fields if tooling and permissions allow.
+- When all required work in the `Current` milestone is `Done`, first check that milestone UX/UI hardening and technical audit are `Done` or explicitly skipped, no milestone pull request remains open in review, and no blocking follow-up must be completed before closeout.
+- If closeout is complete, propose moving the completed milestone's Project items from `Current` to `Closed` and the next milestone's Project items from `Next` to `Current`. After product-owner confirmation, attempt to update the Project fields; if the update fails, use the Project field blocker policy below.
 - A milestone focus transition updates board focus only. It does not authorize implementation of the next roadmap issue.
 - If Project field updates fail because of permissions, missing tooling, unresolved Project metadata, GitHub availability, or another blocker, report the limitation and ask for the concrete access, authorization, or Project metadata needed to complete the update.
 

--- a/docs/roadmap/roadmap-process.md
+++ b/docs/roadmap/roadmap-process.md
@@ -61,7 +61,7 @@ Create these saved Project views:
 - An issue enters `Ready` only when objective, scope, out-of-scope, acceptance criteria, and verification are clear.
 - Do not apply the `ready` label or add the issue to the Project as ready until the roadmap issue validator passes.
 - Keep issues small enough for a PR review of about 15-30 minutes.
-- Each roadmap issue added to the Project should have both a GitHub Milestone and a `Milestone Focus` value. Use `Current` for active milestone work, `Next` for the next planned milestone, `Later` for future milestone work, and `Closed` for completed milestone work after closeout is accepted.
+- Each roadmap issue added to the Project must have both a GitHub Milestone and a `Milestone Focus` value. Use `Current` for active milestone work, `Next` for the next planned milestone, `Later` for future milestone work, and `Closed` for completed milestone work after closeout is accepted.
 
 ## Milestone Project Board Focus
 
@@ -243,11 +243,11 @@ The GitHub Project tracks roadmap issues as the status owner. Pull requests are 
 1. The product owner asks for the next task.
 2. The agent reviews the GitHub Project.
 3. If the agent cannot review the GitHub Project because authentication, permissions, tooling, network access, or Project metadata is unavailable, the agent asks the product owner for the concrete access, re-authentication, authorization, or Project metadata needed to inspect it before recommending an executable task. When a CLI or app can start an interactive authorization flow, the agent starts that flow and gives the product owner the exact URL, code, or approval prompt to complete, instead of only describing commands for the product owner to run. Issue labels, issue sidebars, and public issue HTML are not substitutes for the Project status.
-4. The agent proposes one issue with the `ready` label and explains the recommendation.
+4. The agent proposes one issue whose Project status is `Ready` and whose labels include `ready`, then explains the recommendation.
 5. The product owner confirms the issue or selects another one.
 6. The agent creates a branch named `codex/<issue-number>-<short-name>`.
 7. Immediately after branch creation, before implementation edits, the agent attempts to move the confirmed issue from `Ready` to `In Progress` in the GitHub Project.
-8. If the Project update cannot be performed because of permissions, missing tooling, unresolved Project metadata, or GitHub availability, the agent reports the limitation and requests the manual move of issue `#<issue-number>` to `In Progress`, or gets explicit product-owner approval to continue despite the temporary Project mismatch.
+8. If the Project update cannot be performed because of permissions, missing tooling, unresolved Project metadata, GitHub availability, or another blocker, the agent reports the limitation and asks the product owner for the permissions, authorization, or Project metadata needed to complete the update, or for explicit authorization to continue while the Project status remains temporarily unchanged. The agent does not request a manual Project move unless the product owner explicitly chooses that fallback.
 9. The agent implements the issue scope using the maintainability and scope balance convention.
 10. The agent runs the required verification.
 11. The agent opens a PR linked with `Closes #<issue-number>`, and the issue moves to `In Review`.

--- a/docs/roadmap/roadmap-process.md
+++ b/docs/roadmap/roadmap-process.md
@@ -38,6 +38,20 @@ Create these labels:
 - `blocked`
 - `ready`
 
+Create a single-select Project field named `Milestone Focus` with these values:
+
+- `Current`
+- `Next`
+- `Later`
+- `Closed`
+
+GitHub Milestones remain the canonical issue-level phase assignment. `Milestone Focus` controls which milestone appears in the daily Project board view.
+
+Create these saved Project views:
+
+- `Active Milestone`: board layout, filtered to `Milestone Focus:Current`, with columns grouped by `Status`.
+- `Milestone Overview`: global view showing all roadmap items with GitHub Milestone, `Milestone Focus`, `Status`, labels, and linked pull requests visible.
+
 ## Issue Rules
 
 - One issue should map to one branch and one pull request by default.
@@ -47,6 +61,30 @@ Create these labels:
 - An issue enters `Ready` only when objective, scope, out-of-scope, acceptance criteria, and verification are clear.
 - Do not apply the `ready` label or add the issue to the Project as ready until the roadmap issue validator passes.
 - Keep issues small enough for a PR review of about 15-30 minutes.
+- Each roadmap issue added to the Project should have both a GitHub Milestone and a `Milestone Focus` value. Use `Current` for active milestone work, `Next` for the next planned milestone, `Later` for future milestone work, and `Closed` for completed milestone work after closeout is accepted.
+
+## Milestone Project Board Focus
+
+The Project board should make the active milestone clear without requiring the product owner to inspect the separate Issues milestone page.
+
+Use `Milestone Focus` as operational Project metadata:
+
+- `Current`: issues in the milestone that should be visible in the daily board.
+- `Next`: issues in the next planned milestone.
+- `Later`: future milestone work that should remain out of the daily board.
+- `Closed`: completed milestone work that remains visible in the global view.
+
+The `Active Milestone` view is the default daily execution board. It filters to `Milestone Focus:Current` and keeps the existing `Status` columns.
+
+The `Milestone Overview` view is the planning and review view. It shows all roadmap items and should make GitHub Milestone and `Milestone Focus` visible so work can be compared across phases.
+
+`Milestone Focus` does not change readiness or task selection. An executable task still requires Project status `Ready`, the `ready` label, and product-owner confirmation.
+
+When all required work in the `Current` milestone is `Done`, first check that milestone UX/UI hardening and technical audit are `Done` or explicitly skipped, no milestone pull request remains open in review, and no blocking follow-up must be completed before closeout.
+
+If closeout is complete, propose moving the completed milestone's Project items from `Current` to `Closed` and the next milestone's Project items from `Next` to `Current`. After product-owner confirmation, attempt to update the Project fields; if the update fails, report the blocker and ask for the concrete access, authorization, or Project metadata needed to complete the update.
+
+A focus transition updates board visibility only. It does not authorize implementation of the next roadmap issue.
 
 ## Product Owner Idea Intake
 
@@ -58,7 +96,7 @@ Use this intake sequence:
 
 1. Classify the idea as a UX/UI finding, technical audit finding, new roadmap task, or PRD-level idea.
 2. If it fits the current milestone hardening or technical audit issue, record it there with enough context to evaluate later.
-3. If it is a standalone roadmap task, ask only the clarifying questions needed to define objective, scope, out-of-scope, acceptance criteria, verification, milestone, labels, and expected PR size.
+3. If it is a standalone roadmap task, ask only the clarifying questions needed to define objective, scope, out-of-scope, acceptance criteria, verification, milestone, `Milestone Focus`, labels, and expected PR size.
 4. If the idea is too large for one 15-30 minute reviewable PR, split it before issue creation and recommend the first issue to create.
 5. Draft the issue using `.github/ISSUE_TEMPLATE/roadmap-task.md`.
 6. Validate the draft before applying `ready` or adding it to the Project as ready:
@@ -70,6 +108,8 @@ Use this intake sequence:
 7. Ask the product owner to confirm issue creation, readiness, and priority.
 
 Intake confirmation can create or update the issue, mark it `Ready`, and set its priority, but it does not authorize implementation. Ideas become implementation work only when the product owner explicitly selects or confirms a ready issue for work under the Agent Cycle. Clear ideas should move toward `Ready`; unclear ideas should stay blocked by named decisions rather than relying on hidden assumptions.
+
+Intake should recommend a `Milestone Focus` value. Future-milestone ideas should usually receive `Later` unless the product owner explicitly promotes that milestone to `Next`.
 
 ## Milestone Technical Audit
 

--- a/docs/superpowers/plans/2026-05-10-milestone-project-board-focus.md
+++ b/docs/superpowers/plans/2026-05-10-milestone-project-board-focus.md
@@ -1,0 +1,367 @@
+# Milestone Project Board Focus Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document and apply a GitHub Project milestone focus convention so the roadmap board has one active milestone view and one global milestone overview.
+
+**Architecture:** Keep GitHub Milestones as canonical issue metadata and add a Project-only `Milestone Focus` field for board visibility. Update repository workflow docs so future agents assign and advance milestone focus consistently, then manually verify the live GitHub Project views.
+
+**Tech Stack:** Markdown documentation, GitHub Issues, GitHub Projects, `pnpm format:check`, `pnpm validate:commit-message`.
+
+---
+
+## File Structure
+
+- Modify `AGENTS.md`: add the board focus design source of truth and agent operating rules for `Milestone Focus`, issue intake, and milestone advancement.
+- Modify `docs/roadmap/roadmap-process.md`: document the Project field, required views, issue intake impact, and milestone transition workflow for humans.
+- External manual configuration: update the live `dl-graph-studio Roadmap` GitHub Project with the `Milestone Focus` field and two saved views.
+
+## Task 1: Update Agent Operating Instructions
+
+**Files:**
+
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Add the design spec to Source Of Truth**
+
+  In `AGENTS.md`, add this bullet after the existing `2026-05-08-maintainability-scope-balance-design.md` bullet:
+
+  ```md
+  - `docs/superpowers/specs/2026-05-10-milestone-project-board-focus-design.md` defines the GitHub Project milestone focus field, active milestone view, global milestone overview, and milestone focus advancement convention.
+  ```
+
+- [ ] **Step 2: Add the milestone board focus section**
+
+  In `AGENTS.md`, add this section after the `Product Owner Idea Intake` section and before `Milestone UX/UI Hardening`:
+
+  ```md
+  ## Milestone Project Board Focus
+
+  - The `dl-graph-studio Roadmap` GitHub Project must use a single-select Project field named `Milestone Focus` with values `Current`, `Next`, `Later`, and `Closed`.
+  - GitHub Milestones remain the canonical phase assignment for issues. `Milestone Focus` controls Project-board visibility and does not replace the issue milestone.
+  - The Project should have an `Active Milestone` board view filtered to `Milestone Focus:Current` and grouped by the existing `Status` field.
+  - The Project should have a `Milestone Overview` global view that shows all roadmap items with GitHub Milestone, `Milestone Focus`, `Status`, labels, and linked pull requests visible.
+  - When creating or updating a roadmap issue, set both the issue's GitHub Milestone and the Project item's `Milestone Focus` value.
+  - Use `Current` for the active milestone, `Next` for the next planned milestone, `Later` for future milestone work, and `Closed` for completed milestone work after closeout is accepted.
+  - `Milestone Focus` must not change the executable task rule: an executable issue still requires Project status `Ready` and the `ready` label.
+  - When every issue in the `Current` milestone is `Done`, first check that milestone UX/UI hardening and technical audit are `Done` or explicitly skipped, no milestone pull request remains open in review, and no blocking follow-up must be completed before closeout.
+  - If closeout is complete, propose moving the completed milestone's Project items from `Current` to `Closed` and the next milestone's Project items from `Next` to `Current`. After product-owner confirmation, update the Project fields if tooling and permissions allow.
+  - A milestone focus transition updates board focus only. It does not authorize implementation of the next roadmap issue.
+  - If Project field updates fail because of permissions, missing tooling, unresolved Project metadata, GitHub availability, or another blocker, report the limitation and ask for the concrete access, authorization, or Project metadata needed to complete the update.
+  ```
+
+- [ ] **Step 3: Extend idea intake rules with focus metadata**
+
+  In `AGENTS.md`, add this bullet after:
+
+  ```md
+  - Ask focused clarifying questions until the issue has objective, scope, out-of-scope, acceptance criteria, verification, milestone, labels, and an expected PR size that fits the normal 15-30 minute review window.
+  ```
+
+  Add:
+
+  ```md
+  - Recommend a `Milestone Focus` value for each drafted roadmap issue: normally `Current` for active milestone work, `Next` for prepared next-milestone work, and `Later` for future milestone work.
+  ```
+
+- [ ] **Step 4: Review the updated `AGENTS.md` section placement**
+
+  Run:
+
+  ```bash
+  rg -n 'milestone-project-board-focus|Milestone Project Board Focus|Milestone Focus|Recommend a `Milestone Focus`' AGENTS.md
+  ```
+
+  Expected:
+
+  ```text
+  AGENTS.md:<line>:- `docs/superpowers/specs/2026-05-10-milestone-project-board-focus-design.md` defines the GitHub Project milestone focus field, active milestone view, global milestone overview, and milestone focus advancement convention.
+  AGENTS.md:<line>:## Milestone Project Board Focus
+  AGENTS.md:<line>:- The `dl-graph-studio Roadmap` GitHub Project must use a single-select Project field named `Milestone Focus` with values `Current`, `Next`, `Later`, and `Closed`.
+  AGENTS.md:<line>:- Recommend a `Milestone Focus` value for each drafted roadmap issue: normally `Current` for active milestone work, `Next` for prepared next-milestone work, and `Later` for future milestone work.
+  ```
+
+- [ ] **Step 5: Commit `AGENTS.md` changes**
+
+  Validate the commit message:
+
+  ```bash
+  pnpm validate:commit-message -- --message "docs: document milestone focus agent rules"
+  ```
+
+  Expected:
+
+  ```text
+  Commit message format is valid.
+  ```
+
+  Commit:
+
+  ```bash
+  git add AGENTS.md
+  git commit -m "docs: document milestone focus agent rules"
+  ```
+
+## Task 2: Update The Human Roadmap Process
+
+**Files:**
+
+- Modify: `docs/roadmap/roadmap-process.md`
+
+- [ ] **Step 1: Add Project field setup**
+
+  In `docs/roadmap/roadmap-process.md`, add this section after the label list in `## GitHub Setup`:
+
+  ```md
+  Create a single-select Project field named `Milestone Focus` with these values:
+
+  - `Current`
+  - `Next`
+  - `Later`
+  - `Closed`
+
+  GitHub Milestones remain the canonical issue-level phase assignment. `Milestone Focus` controls which milestone appears in the daily Project board view.
+
+  Create these saved Project views:
+
+  - `Active Milestone`: board layout, filtered to `Milestone Focus:Current`, with columns grouped by `Status`.
+  - `Milestone Overview`: global view showing all roadmap items with GitHub Milestone, `Milestone Focus`, `Status`, labels, and linked pull requests visible.
+  ```
+
+- [ ] **Step 2: Add issue focus assignment rule**
+
+  In `docs/roadmap/roadmap-process.md`, add this bullet after:
+
+  ```md
+  - Keep issues small enough for a PR review of about 15-30 minutes.
+  ```
+
+  Add:
+
+  ```md
+  - Each roadmap issue added to the Project should have both a GitHub Milestone and a `Milestone Focus` value. Use `Current` for active milestone work, `Next` for the next planned milestone, `Later` for future milestone work, and `Closed` for completed milestone work after closeout is accepted.
+  ```
+
+- [ ] **Step 3: Extend product-owner idea intake**
+
+  In `docs/roadmap/roadmap-process.md`, replace this list item:
+
+  ```md
+  3. If it is a standalone roadmap task, ask only the clarifying questions needed to define objective, scope, out-of-scope, acceptance criteria, verification, milestone, labels, and expected PR size.
+  ```
+
+  With:
+
+  ```md
+  3. If it is a standalone roadmap task, ask only the clarifying questions needed to define objective, scope, out-of-scope, acceptance criteria, verification, milestone, `Milestone Focus`, labels, and expected PR size.
+  ```
+
+  After this paragraph:
+
+  ```md
+  Intake confirmation can create or update the issue, mark it `Ready`, and set its priority, but it does not authorize implementation. Ideas become implementation work only when the product owner explicitly selects or confirms a ready issue for work under the Agent Cycle. Clear ideas should move toward `Ready`; unclear ideas should stay blocked by named decisions rather than relying on hidden assumptions.
+  ```
+
+  Add:
+
+  ```md
+  Intake should recommend a `Milestone Focus` value. Future-milestone ideas should usually receive `Later` unless the product owner explicitly promotes that milestone to `Next`.
+  ```
+
+- [ ] **Step 4: Add Milestone Project Board Focus section**
+
+  In `docs/roadmap/roadmap-process.md`, add this section after `## Issue Rules` and before `## Product Owner Idea Intake`:
+
+  ```md
+  ## Milestone Project Board Focus
+
+  The Project board should make the active milestone clear without requiring the product owner to inspect the separate Issues milestone page.
+
+  Use `Milestone Focus` as operational Project metadata:
+
+  - `Current`: issues in the milestone that should be visible in the daily board.
+  - `Next`: issues in the next planned milestone.
+  - `Later`: future milestone work that should remain out of the daily board.
+  - `Closed`: completed milestone work that remains visible in the global view.
+
+  The `Active Milestone` view is the default daily execution board. It filters to `Milestone Focus:Current` and keeps the existing `Status` columns.
+
+  The `Milestone Overview` view is the planning and review view. It shows all roadmap items and should make GitHub Milestone and `Milestone Focus` visible so work can be compared across phases.
+
+  `Milestone Focus` does not change readiness or task selection. An executable task still requires Project status `Ready`, the `ready` label, and product-owner confirmation.
+
+  When every issue in the `Current` milestone is `Done`, the agent should check milestone closeout before changing focus:
+
+  - the milestone UX/UI hardening issue is `Done` or explicitly skipped,
+  - the milestone technical audit issue is `Done` or explicitly skipped,
+  - no pull request for the milestone remains open in review,
+  - no blocking follow-up issue must be completed before closing the milestone.
+
+  If closeout is complete, the agent should propose moving the completed milestone from `Current` to `Closed` and the next milestone from `Next` to `Current`. After product-owner confirmation, the agent may update the Project field values if permissions and tooling allow.
+
+  A focus transition updates board visibility only. It does not authorize implementation of the next roadmap issue.
+  ```
+
+- [ ] **Step 5: Review roadmap-process references**
+
+  Run:
+
+  ```bash
+  rg -n "Milestone Project Board Focus|Milestone Focus|Active Milestone|Milestone Overview|milestone closeout" docs/roadmap/roadmap-process.md
+  ```
+
+  Expected: output includes the new setup, issue rules, intake, and focus-transition references.
+
+- [ ] **Step 6: Commit roadmap process changes**
+
+  Validate the commit message:
+
+  ```bash
+  pnpm validate:commit-message -- --message "docs: describe milestone focus roadmap views"
+  ```
+
+  Expected:
+
+  ```text
+  Commit message format is valid.
+  ```
+
+  Commit:
+
+  ```bash
+  git add docs/roadmap/roadmap-process.md
+  git commit -m "docs: describe milestone focus roadmap views"
+  ```
+
+## Task 3: Verify Documentation And Live Project Configuration
+
+**Files:**
+
+- Verify: `AGENTS.md`
+- Verify: `docs/roadmap/roadmap-process.md`
+- External: `dl-graph-studio Roadmap` GitHub Project
+
+- [ ] **Step 1: Run documentation formatting**
+
+  Run:
+
+  ```bash
+  pnpm format:check
+  ```
+
+  Expected:
+
+  ```text
+  All matched files use Prettier code style!
+  ```
+
+- [ ] **Step 2: Verify no executable task rule changed**
+
+  Run:
+
+  ```bash
+  rg -n 'Project status `Ready`|ready` label|Milestone Focus.*does not change|executable task' AGENTS.md docs/roadmap/roadmap-process.md
+  ```
+
+  Expected: output shows both the original `Ready` plus `ready` rule and the new statement that `Milestone Focus` does not change task selection.
+
+- [ ] **Step 3: Configure the live Project field**
+
+  In the `dl-graph-studio Roadmap` GitHub Project, create a single-select field:
+
+  ```text
+  Milestone Focus
+  ```
+
+  Add exactly these options:
+
+  ```text
+  Current
+  Next
+  Later
+  Closed
+  ```
+
+  Expected: the Project table can show and edit `Milestone Focus` for roadmap items.
+
+- [ ] **Step 4: Create the `Active Milestone` view**
+
+  In the GitHub Project, create or update a saved view named:
+
+  ```text
+  Active Milestone
+  ```
+
+  Configure it as:
+
+  ```text
+  Layout: Board
+  Filter: Milestone Focus:Current
+  Columns/grouping: Status
+  Visible fields/cards: Milestone, labels, linked pull requests, assignee when available
+  ```
+
+  Expected: the board shows only items with `Milestone Focus` set to `Current` and keeps the normal status columns.
+
+- [ ] **Step 5: Create the `Milestone Overview` view**
+
+  In the GitHub Project, create or update a saved view named:
+
+  ```text
+  Milestone Overview
+  ```
+
+  Configure it as:
+
+  ```text
+  Layout: Table or Board, whichever makes milestone comparison clearer in GitHub's current UI
+  Filter: no milestone-focus filter
+  Visible fields: Milestone, Milestone Focus, Status, labels, linked pull requests
+  Group/sort: by Milestone and Milestone Focus when available
+  ```
+
+  Expected: the view shows active, next, later, and closed milestone work together without hiding completed milestones.
+
+- [ ] **Step 6: Assign initial focus values**
+
+  Set current Project items as follows unless the product owner gives different roadmap direction:
+
+  ```text
+  Current: all issues in the currently active milestone
+  Next: prepared issues in the next planned milestone
+  Later: future milestone issues
+  Closed: issues in completed milestones
+  ```
+
+  Expected: `Active Milestone` becomes the daily board and no longer mixes cards from unrelated milestones.
+
+- [ ] **Step 7: Validate final commit message and commit any remaining doc changes**
+
+  If Task 3 required documentation corrections, validate:
+
+  ```bash
+  pnpm validate:commit-message -- --message "docs: verify milestone focus workflow"
+  ```
+
+  Expected:
+
+  ```text
+  Commit message format is valid.
+  ```
+
+  Commit only if files changed:
+
+  ```bash
+  git add AGENTS.md docs/roadmap/roadmap-process.md
+  git commit -m "docs: verify milestone focus workflow"
+  ```
+
+  If no files changed, do not create an empty commit.
+
+## Self-Review
+
+- Spec coverage: Task 1 updates agent instructions; Task 2 updates the human roadmap process; Task 3 covers formatting and live GitHub Project manual verification.
+- Completeness scan: every task names exact files, exact inserted text, commands,
+  and expected results.
+- Scope check: the plan does not add automation, does not change product code, and does not start next-milestone implementation.
+- Rule consistency: the `Ready` plus `ready` executable task rule remains explicit and unchanged.

--- a/docs/superpowers/specs/2026-05-10-milestone-project-board-focus-design.md
+++ b/docs/superpowers/specs/2026-05-10-milestone-project-board-focus-design.md
@@ -1,0 +1,184 @@
+# Milestone Project Board Focus Design
+
+## Context
+
+`dl-graph-studio` uses GitHub Issues and the `dl-graph-studio Roadmap`
+GitHub Project as the operational source of truth for executable roadmap work.
+The existing workflow already defines product milestones, roadmap issue
+contracts, Project statuses, milestone UX/UI hardening, and milestone technical
+audits.
+
+The current Project board is status-oriented. That makes the execution state of
+each issue visible, but it does not clearly separate issues from different
+milestones inside the board itself. The product owner currently has to leave the
+Project view and inspect the Issues milestone area to understand which cards
+belong to one phase versus another.
+
+## Goal
+
+Make milestone focus visible directly in the GitHub Project while preserving
+the existing issue, status, and product-owner confirmation workflow.
+
+The daily board should show the active milestone without requiring manual view
+filter edits when the project moves from one phase to the next. The global view
+should still make all milestones visible for planning and review.
+
+## Non-Goals
+
+- Do not replace GitHub Milestones as the canonical issue-level phase metadata.
+- Do not change the existing Project status values.
+- Do not automatically start implementation of the next milestone.
+- Do not add GitHub Actions or background automation for Project field updates.
+- Do not create a separate GitHub Project per milestone.
+
+## Recommended Project Field
+
+Add a single-select Project field named:
+
+```text
+Milestone Focus
+```
+
+Use these values:
+
+- `Current`: issues in the milestone that should be visible in the daily board.
+- `Next`: issues in the next planned milestone.
+- `Later`: future milestone work that should remain out of the daily board.
+- `Closed`: completed milestone work that remains visible in the global view.
+
+This field is operational Project metadata. The GitHub Milestone on each issue
+remains the canonical milestone assignment, such as
+`Phase 1 - Core architecture editor`.
+
+## Required Project Views
+
+### Active Milestone
+
+Create a saved board view named:
+
+```text
+Active Milestone
+```
+
+This view should:
+
+- use board layout,
+- filter to `Milestone Focus:Current`,
+- keep columns grouped by the existing `Status` field,
+- show enough card metadata to reveal milestone, labels, linked pull requests,
+  and assignee when available.
+
+This is the default daily execution view. It should answer: "What is happening
+in the active milestone right now?"
+
+### Milestone Overview
+
+Create a saved global view named:
+
+```text
+Milestone Overview
+```
+
+This view should:
+
+- show all roadmap Project items,
+- expose GitHub Milestone, `Milestone Focus`, `Status`, labels, and linked pull
+  requests,
+- group or sort by milestone and focus when GitHub's Project view options allow
+  it,
+- keep closed milestones visible without mixing them into the active board.
+
+This is the planning and review view. It should answer: "How is work distributed
+across milestones?"
+
+## Agent Workflow
+
+When an agent creates or updates a roadmap issue, it should set both:
+
+- the issue's GitHub Milestone,
+- the Project item's `Milestone Focus` value.
+
+Default assignment rules:
+
+- active milestone issues use `Current`,
+- the next planned milestone's prepared issues use `Next`,
+- future milestone issues use `Later`,
+- completed milestone issues use `Closed` after milestone closeout is accepted.
+
+The `ready` label and Project `Status` still control executable task selection.
+`Milestone Focus` only controls milestone visibility and focus.
+
+## Milestone Advancement
+
+When every issue in the `Current` milestone is `Done`, the agent should not
+silently advance the roadmap. It should first check whether milestone closeout is
+complete:
+
+- the milestone UX/UI hardening issue is `Done` or explicitly skipped,
+- the milestone technical audit issue is `Done` or explicitly skipped,
+- no pull request for the milestone remains open in review,
+- no blocking follow-up issue must be completed before closing the milestone.
+
+If the closeout check passes, the agent should propose the focus transition to
+the product owner:
+
+- move the completed milestone's Project items from `Current` to `Closed`,
+- move the next milestone's Project items from `Next` to `Current`,
+- keep later milestone work as `Later`.
+
+After product-owner confirmation, the agent may update the Project fields. This
+updates board focus only; it does not authorize implementation of the next
+roadmap issue.
+
+If the agent cannot update Project fields because of permissions, missing
+tooling, unresolved Project metadata, or GitHub availability, it should report
+the blocker and ask for the concrete access or authorization needed to complete
+the update.
+
+## Issue Intake Impact
+
+Product-owner idea intake should recommend a GitHub Milestone and `Milestone
+Focus` value for each drafted roadmap issue. The issue can be proposed as
+`Ready` only when the normal roadmap issue contract is complete.
+
+Ideas that belong to a future milestone should usually receive `Later` unless
+the product owner explicitly promotes that milestone to `Next`.
+
+## Acceptance Criteria
+
+- [ ] The roadmap process documents the `Milestone Focus` field and required
+      Project views.
+- [ ] Agent operating instructions require milestone focus assignment when
+      creating or updating roadmap issues.
+- [ ] The milestone advancement rule is documented as product-owner confirmed,
+      not silent automation.
+- [ ] The existing `Ready` plus `ready` executable task rule remains unchanged.
+- [ ] The design avoids requiring manual filter edits whenever the active
+      milestone changes.
+
+## Verification
+
+Automated:
+
+- [ ] Run `pnpm format:check` for documentation formatting.
+
+Manual:
+
+- [ ] In the GitHub Project, confirm an `Active Milestone` view can filter to
+      `Milestone Focus:Current` and still show status columns.
+- [ ] Confirm a `Milestone Overview` view can show all roadmap items with
+      GitHub Milestone and `Milestone Focus` visible.
+- [ ] Confirm the agent workflow explains when to propose moving focus from one
+      milestone to the next.
+
+## Rationale
+
+Using a Project field separates board focus from issue identity. GitHub
+Milestones remain the durable source for phase assignment, while `Milestone
+Focus` gives the Project board a simple way to show the active phase without
+editing saved filters for every milestone transition.
+
+Requiring the agent to propose advancement after 100% `Done` preserves
+product-owner control. A milestone may still need final review, hardening,
+technical audit, or explicit deferral decisions before the next phase becomes
+the active board focus.


### PR DESCRIPTION
## Summary

- Document the `Milestone Focus` workflow in agent and human roadmap process docs.
- Add the brainstorming design spec and implementation plan for the Project board focus convention.
- Configure the live Roadmap Project with `Milestone Focus`, `Active Milestone`, and `Milestone Overview`.

## Linked issue

Closes #61

## Verification

Automated:

- [x] `pnpm format:check` - passes.
- [x] `pnpm validate:commit-message -- --range origin/main..HEAD` - passes.

Manual:

- [x] Inspected `AGENTS.md` and `docs/roadmap/roadmap-process.md` for the new milestone focus workflow.
- [x] Confirmed the live `dl-graph-studio Roadmap` Project has `Milestone Focus` with `Current`, `Next`, `Later`, and `Closed`.
- [x] Confirmed `Active Milestone` is a board view filtered to `milestone-focus:Current`.
- [x] Confirmed `Milestone Overview` is a global table view grouped by Milestone with `Milestone`, `Milestone Focus`, `Status`, `Labels`, and linked pull requests visible.
- [x] Confirmed completed Project items are `Closed`, and active Phase 2 issues #60 and #61 are `Current`.

## Screenshots / video

Not applicable. This PR changes workflow documentation and GitHub Project configuration, not application UI.

## Definition of Done

- [x] This PR addresses exactly one roadmap issue, unless the issue explicitly allows grouping.
- [x] The PR description explains what changed and how to verify it.
- [x] Acceptance criteria from the issue are satisfied or explicitly explained.
- [x] Automated tests pass where tests exist.
- [x] New behavior has suitable test coverage when practical.
- [x] UI changes include screenshots or a short video/GIF.
- [x] Manual verification steps have been run and documented.
- [x] No unrelated refactors or scope creep are included.
- [x] Documentation is updated when behavior, architecture, or workflow changes.

## Notes

- `Active Milestone` intentionally shows only `Current` items, so completed Phase 1 work stays out of the daily board.
- `Milestone Overview` remains unfiltered so closed and future milestone work remain visible for planning.
